### PR TITLE
Add support for pasting images

### DIFF
--- a/src/components/form/useClipboardImage.ts
+++ b/src/components/form/useClipboardImage.ts
@@ -1,0 +1,38 @@
+import { useEffect, useState } from 'react'
+import { useNotification } from '../../hooks/notificationHook'
+
+export const useClipboardImage = (enable: boolean) => {
+    const [image, setImage] = useState<File | null>(null)
+    const { createNotification } = useNotification()
+
+    useEffect(() => {
+        if (!enable) return
+
+        const listener = (e: ClipboardEvent) => {
+            if (e.clipboardData) {
+                const items = e.clipboardData.items
+                if (!items) return
+                for (let i = 0; i < items.length; i++) {
+                    if (items[i].type.indexOf('image') !== -1) {
+                        const blob = items[i].getAsFile()
+                        if (!blob) {
+                            continue
+                        }
+                        setImage(blob)
+                        e.preventDefault()
+                        createNotification('Image pasted', { type: 'success' })
+                        break
+                    }
+                }
+            }
+        }
+
+        document.addEventListener('paste', listener, false)
+
+        return () => {
+            document.removeEventListener('paste', listener, false)
+        }
+    }, [enable])
+
+    return image
+}

--- a/src/components/sidepanel/SidePanelImageUpload.tsx
+++ b/src/components/sidepanel/SidePanelImageUpload.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { useCallback, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import { SidePanel } from './SidePanel'
 import { useDropzone } from 'react-dropzone'
 import { SidePanelImageUploadForm } from './SidePanelImageUploadForm'
@@ -8,6 +8,7 @@ import { uploadImage } from '../../utils/images/uploadImage'
 import { Event } from '../../types'
 import { useController } from 'react-hook-form'
 import { useNotification } from '../../hooks/notificationHook'
+import { useClipboardImage } from '../form/useClipboardImage'
 
 export type SidePanelImageUploadProps = {
     event: Event
@@ -32,6 +33,17 @@ export const SidePanelImageUpload = ({
         preview: any
     } | null>(null)
     const [uploading, setUploading] = useState(false)
+
+    const imageFromClipboard = useClipboardImage(isOpen)
+
+    useEffect(() => {
+        if (imageFromClipboard && !upload) {
+            setUpload({
+                file: imageFromClipboard,
+                preview: URL.createObjectURL(imageFromClipboard),
+            })
+        }
+    }, [imageFromClipboard])
 
     const onSave = async () => {
         setUploading(true)

--- a/src/components/sidepanel/SidePanelImageUpload.tsx
+++ b/src/components/sidepanel/SidePanelImageUpload.tsx
@@ -95,7 +95,7 @@ export const SidePanelImageUpload = ({
                 fieldName={fieldName}
                 onInputClick={open}
                 onSaveClick={onSave}
-                helpText="PNG or JPEG image, will be resized in the browser."
+                helpText="PNG or JPEG image, will be resized in the browser. You can also paste image directly from clipboard."
             />
         </SidePanel>
     )


### PR DESCRIPTION
- you can now paste image using (ctrl+v or cmd+v) from a copy of an image of another tab when the side panel image upload is open 