### PR TITLE
Add new reimport buttons to add CH event later on

### DIFF
--- a/src/components/ConfirmDialog.tsx
+++ b/src/components/ConfirmDialog.tsx
@@ -6,7 +6,7 @@ export type ConfirmDialogProps = {
     open: boolean
     handleClose: () => void
     title: string | undefined
-    acceptButton: string
+    acceptButton?: string
     cancelButton: string
     handleAccept: () => void
     disabled?: boolean
@@ -35,14 +35,16 @@ export const ConfirmDialog = ({
             <DialogContent>{children}</DialogContent>
             <DialogActions>
                 <Button onClick={handleClose}>{cancelButton}</Button>
-                <LoadingButton
-                    onClick={handleAccept}
-                    disabled={disabled}
-                    loading={loading}
-                    autoFocus
-                    variant="contained">
-                    {acceptButton}
-                </LoadingButton>
+                {acceptButton && (
+                    <LoadingButton
+                        onClick={handleAccept}
+                        disabled={disabled}
+                        loading={loading}
+                        autoFocus
+                        variant="contained">
+                        {acceptButton}
+                    </LoadingButton>
+                )}
             </DialogActions>
         </Dialog>
     )

--- a/src/conferencehall/components/ConferenceHallProposalsPickerConnected.tsx
+++ b/src/conferencehall/components/ConferenceHallProposalsPickerConnected.tsx
@@ -3,6 +3,7 @@ import React, { useState } from 'react'
 import { ConferenceHallProposal, Format } from '../../types'
 import { ConferenceHallFormatsMapping } from './ConferenceHallFormatsMapping'
 import { useConferenceHallProposals } from '../hooks/useConferenceHallProposals'
+import { mapConferenceHallFormatsToOpenPlanner } from '../../events/actions/conferenceHallUtils/mapFromConferenceHallToOpenPlanner'
 
 type ConferenceHallProposalsPickerConnectedProps = {
     conferenceHallEventId: string
@@ -27,12 +28,7 @@ export const ConferenceHallProposalsPickerConnected = ({
     submitText,
 }: ConferenceHallProposalsPickerConnectedProps) => {
     const proposals = useConferenceHallProposals(conferenceHallEventId)
-    const [formats, setFormatDurations] = useState<Format[]>(
-        (chFormats || []).map((f) => ({
-            ...f,
-            durationMinutes: 20,
-        }))
-    )
+    const [formats, setFormatDurations] = useState<Format[]>(mapConferenceHallFormatsToOpenPlanner(chFormats))
 
     const submitSelectedProposalsAndFormats = (proposals: ConferenceHallProposal[]) => {
         return onSubmit({

--- a/src/conferencehall/firebase/conferenceHallFirebase.ts
+++ b/src/conferencehall/firebase/conferenceHallFirebase.ts
@@ -1,5 +1,5 @@
 import { initializeApp } from 'firebase/app'
-import { collection, CollectionReference, getFirestore } from '@firebase/firestore'
+import { collection, doc, CollectionReference, DocumentReference, getFirestore } from '@firebase/firestore'
 
 const config = {
     apiKey: import.meta.env.VITE_FIREBASE_CONFERENCE_HALL_API_KEY,
@@ -13,6 +13,7 @@ export const conferenceHallFirestore = getFirestore(conferenceHallFirebaseApp)
 export const conferenceHallCollections = {
     organizations: collection(conferenceHallFirestore, 'organizations'),
     events: collection(conferenceHallFirestore, 'events'),
+    event: (eventId: string): DocumentReference => doc(conferenceHallFirestore, 'events', eventId),
     proposals: (eventId: string): CollectionReference =>
         collection(conferenceHallFirestore, 'events', eventId, 'proposals'),
     users: collection(conferenceHallFirestore, 'users'),

--- a/src/conferencehall/firebase/getConferenceHallEvent.ts
+++ b/src/conferencehall/firebase/getConferenceHallEvent.ts
@@ -1,0 +1,9 @@
+import { getDoc } from 'firebase/firestore'
+import { conferenceHallCollections } from './conferenceHallFirebase'
+import { ConferenceHallEvent } from '../../types'
+
+export const getConferenceHallEvent = async (chEventId: string) => {
+    const snapshot = await getDoc(conferenceHallCollections.event(chEventId))
+
+    return snapshot.data() as ConferenceHallEvent
+}

--- a/src/events/actions/addNewEvent.ts
+++ b/src/events/actions/addNewEvent.ts
@@ -5,7 +5,7 @@ import { loadConferenceHallSpeakers } from '../../conferencehall/firebase/loadFr
 import { importSpeakers } from './conferenceHallUtils/importSpeakers'
 import { importSessions } from './conferenceHallUtils/importSessions'
 import { getNewEventDates } from './conferenceHallUtils/addNewEventDateUtils'
-import { randomColor } from '../../utils/randomColor'
+import { mapConferenceHallCategoriesToOpenPlanner } from './conferenceHallUtils/mapFromConferenceHallToOpenPlanner'
 
 export const addNewEvent = async (
     chEvent: ConferenceHallEvent,
@@ -48,11 +48,7 @@ const addNewEventInternal = async (
         owner: userId,
         tracks: [],
         formats: formats,
-        categories: (chEvent.categories || []).map((e) => ({
-            name: e.name,
-            id: e.id,
-            color: randomColor(),
-        })),
+        categories: mapConferenceHallCategoriesToOpenPlanner(chEvent.categories),
         apiKey: null,
         scheduleVisible: true,
         webhooks: [],

--- a/src/events/actions/conferenceHallUtils/mapFromConferenceHallToOpenPlanner.ts
+++ b/src/events/actions/conferenceHallUtils/mapFromConferenceHallToOpenPlanner.ts
@@ -1,5 +1,14 @@
-import { ConferenceHallProposal, ConferenceHallSpeaker, Format, Session, Social, Speaker } from '../../../types'
+import {
+    Category,
+    ConferenceHallProposal,
+    ConferenceHallSpeaker,
+    Format,
+    Session,
+    Social,
+    Speaker,
+} from '../../../types'
 import { slugify } from '../../../utils/slugify'
+import { randomColor } from '../../../utils/randomColor'
 
 export const mapConferenceHallSpeakerToOpenPlanner = (
     speakerIds: string[],
@@ -93,4 +102,30 @@ export const mapConferenceHallProposalsToOpenPlanner = (
         })
     }
     return [sessions, errors]
+}
+
+export const mapConferenceHallFormatsToOpenPlanner = (
+    chFormats: { id: string; name: string }[] | undefined,
+    defaultDurationMinutes = 20
+): Format[] => {
+    if (!chFormats) {
+        return []
+    }
+    return chFormats.map((f) => ({
+        id: f.id,
+        name: f.name,
+        durationMinutes: defaultDurationMinutes,
+    }))
+}
+export const mapConferenceHallCategoriesToOpenPlanner = (
+    chCategories: { id: string; name: string }[] | undefined
+): Category[] => {
+    if (!chCategories) {
+        return []
+    }
+    return chCategories.map((f) => ({
+        id: f.id,
+        name: f.name,
+        color: randomColor(),
+    }))
 }

--- a/src/events/actions/linkOpenPlannerEventToConferenceHallEvent.ts
+++ b/src/events/actions/linkOpenPlannerEventToConferenceHallEvent.ts
@@ -1,0 +1,9 @@
+import { doc, serverTimestamp, updateDoc } from 'firebase/firestore'
+import { collections } from '../../services/firebase'
+
+export const linkOpenPlannerEventToConferenceHallEvent = async (eventId: string, conferenceHallEventId: string) => {
+    return await updateDoc(doc(collections.events, eventId), {
+        conferenceHallId: conferenceHallEventId,
+        updatedAt: serverTimestamp(),
+    })
+}

--- a/src/events/actions/reImportSessionsSpeakersFromConferenceHall.ts
+++ b/src/events/actions/reImportSessionsSpeakersFromConferenceHall.ts
@@ -20,9 +20,11 @@ export const reImportSessionsSpeakersFromConferenceHall = async (event: Event, r
         return
     }
 
+    let formats = event.formats
+
     if (reImportCategoriesFormats) {
         const chEvent = await getConferenceHallEvent(conferenceHallId)
-        const formats = mapConferenceHallFormatsToOpenPlanner(chEvent.formats)
+        formats = mapConferenceHallFormatsToOpenPlanner(chEvent.formats)
         const categories = mapConferenceHallCategoriesToOpenPlanner(chEvent.categories)
 
         await updateDoc(doc(collections.events, event.id), {
@@ -57,7 +59,7 @@ export const reImportSessionsSpeakersFromConferenceHall = async (event: Event, r
         console.error(speakerErrors)
     }
 
-    const [_, sessionErrors] = await importSessions(event.id, proposals, event.formats, speakerMapToCC, () => null)
+    const [_, sessionErrors] = await importSessions(event.id, proposals, formats, speakerMapToCC, () => null)
     if (sessionErrors.length) {
         console.error(sessionErrors)
     }

--- a/src/events/page/settings/EventSettings.tsx
+++ b/src/events/page/settings/EventSettings.tsx
@@ -2,7 +2,17 @@ import * as React from 'react'
 import { useEffect, useState } from 'react'
 import { Event, EventForForm } from '../../../types'
 import { yupResolver } from '@hookform/resolvers/yup'
-import { Box, Button, Card, Container, DialogContentText, Grid, Typography } from '@mui/material'
+import {
+    Box,
+    Button,
+    Card,
+    Checkbox,
+    Container,
+    DialogContentText,
+    FormControlLabel,
+    Grid,
+    Typography,
+} from '@mui/material'
 import { FormContainer, TextFieldElement, useForm } from 'react-hook-form-mui'
 import LoadingButton from '@mui/lab/LoadingButton'
 import * as yup from 'yup'
@@ -49,6 +59,7 @@ export const EventSettings = ({ event }: EventSettingsProps) => {
     const [_, setLocation] = useLocation()
     const [deleteOpen, setDeleteOpen] = useState(false)
     const [reImportOpen, setReimportOpen] = useState(false)
+    const [reImportCategoriesFormats, setReImportCategoriesFormat] = useState(false)
     const [loading, setLoading] = useState(false)
     const { createNotification } = useNotification()
     const documentDeletion = useFirestoreDocumentDeletion(doc(collections.events, event.id))
@@ -181,7 +192,7 @@ export const EventSettings = ({ event }: EventSettingsProps) => {
                     handleClose={() => setReimportOpen(false)}
                     handleAccept={async () => {
                         setLoading(true)
-                        await reImportSessionsSpeakersFromConferenceHall(event)
+                        await reImportSessionsSpeakersFromConferenceHall(event, reImportCategoriesFormats)
                         setLoading(false)
                         setReimportOpen(false)
                         createNotification('Data imported', { type: 'success' })
@@ -197,6 +208,18 @@ export const EventSettings = ({ event }: EventSettingsProps) => {
                         - cannot be cancelled (it would be cool to have versioning in the future though...)
                         <br />
                         <br />
+                        <FormControlLabel
+                            control={
+                                <Checkbox
+                                    checked={reImportCategoriesFormats}
+                                    onChange={(e) => {
+                                        setReImportCategoriesFormat(e.target.checked)
+                                    }}
+                                    inputProps={{ 'aria-label': 'controlled' }}
+                                />
+                            }
+                            label="Replace categories & formats?"
+                        />
                     </DialogContentText>
 
                     <RequireConferenceHallLogin>


### PR DESCRIPTION
If you use OpenPlanner as your backend your the conference website, you may have created the event without using the ConferenceHall import button. 
So solve this issue, this PR add two new features: 
1. Add option to attach the OpenPlanner event to a ConferenceHall event. 
2. Add the option to, while you reimport speaker and sessions using the already present button, also import format & categories. 