### PR TITLE
Improve session add update mechanism, add remove from schedule button and more

### DIFF
--- a/src/events/actions/conferenceHallUtils/importSessions.ts
+++ b/src/events/actions/conferenceHallUtils/importSessions.ts
@@ -3,12 +3,14 @@ import { collections } from '../../../services/firebase'
 import { mapConferenceHallProposalsToOpenPlanner } from './mapFromConferenceHallToOpenPlanner'
 import { ConferenceHallProposal, Format } from '../../../types'
 
+export const UPDATE_FIELDS_SESSIONS = ['title', 'abstract', 'language', 'level', 'speakers', 'tags']
 export const importSessions = async (
     eventId: string,
     proposals: ConferenceHallProposal[],
     formats: Format[],
     speakersMappingFromConferenceHall: { [id: string]: string },
-    progress: (progress: string) => void
+    progress: (progress: string) => void,
+    shouldUpdateSession: boolean = false
 ): Promise<[sessionIds: string[], error: string[]]> => {
     const errors = []
     const [sessionsToCreate, sessionsErrors] = mapConferenceHallProposalsToOpenPlanner(
@@ -20,7 +22,16 @@ export const importSessions = async (
     const createdSessionIds = []
     let countSessionsAdded = 1
     for (const session of sessionsToCreate) {
-        await setDoc(doc(collections.sessions(eventId), session.id), session)
+        if (shouldUpdateSession) {
+            const sessionToUpdate: { [key: string]: any } = {}
+            for (const field of UPDATE_FIELDS_SESSIONS) {
+                // @ts-ignore
+                sessionToUpdate[field] = session[field]
+            }
+            await setDoc(doc(collections.sessions(eventId), session.id), sessionToUpdate, { merge: true })
+        } else {
+            await setDoc(doc(collections.sessions(eventId), session.id), session)
+        }
         createdSessionIds.push(session.id)
         progress(`Adding sessions: ${countSessionsAdded}/${sessionsToCreate.length}`)
         countSessionsAdded++

--- a/src/events/actions/sessions/addSessionsFromCH.ts
+++ b/src/events/actions/sessions/addSessionsFromCH.ts
@@ -32,7 +32,8 @@ export const addSessionsFromCH = async (
         proposals,
         event.formats,
         speakersMappingFromConferenceHall,
-        progressCallback
+        progressCallback,
+        true
     )
     errors.push(...sessionErrors)
 

--- a/src/events/page/schedule/EventScheduleTemplate.tsx
+++ b/src/events/page/schedule/EventScheduleTemplate.tsx
@@ -84,7 +84,11 @@ export const EventScheduleTemplate = ({ event }: EventScheduleTemplateProps) => 
                 <Box></Box>
             </Box>
             <FirestoreQueryLoaderAndErrorDisplay hookResult={sessionsTemplate} />
-            <NoDatesSessionsPicker sessions={sessionsTemplate} title="Not placed template" />
+            <NoDatesSessionsPicker
+                sessions={sessionsTemplate}
+                title="Not placed template"
+                Component={TemplateCardContent}
+            />
             <FullCalendarBase
                 event={event}
                 daysToDisplay={daysToDisplay}

--- a/src/events/page/schedule/NoDatesSessionsPicker.tsx
+++ b/src/events/page/schedule/NoDatesSessionsPicker.tsx
@@ -8,12 +8,14 @@ import { SessionDraggable } from './components/SessionDraggable'
 import { Draggable } from '@fullcalendar/interaction'
 import { useLocation } from 'wouter'
 import { UseQueryResult } from '../../../services/hooks/firestoreQueryHook'
+import { SessionCardContentProps } from './components/SessionCardContent'
 
 export type NoDatesSessionsPickerProps = {
     sessions: UseQueryResult<DocumentData>
     title: string
+    Component?: React.ComponentType<SessionCardContentProps>
 }
-export const NoDatesSessionsPicker = ({ sessions, title }: NoDatesSessionsPickerProps) => {
+export const NoDatesSessionsPicker = ({ sessions, title, Component }: NoDatesSessionsPickerProps) => {
     const [sessionsToDisplay, setSessionsToDisplay] = useState<Session[]>([])
     const [_, setLocation] = useLocation()
     const [isDragInit, setIsDragInit] = useState(false)
@@ -76,10 +78,11 @@ export const NoDatesSessionsPicker = ({ sessions, title }: NoDatesSessionsPicker
                 borderRadius: 2,
                 overflowX: 'auto',
                 overflowY: 'hidden',
+                backdropFilter: 'blur(10px)',
             }}>
             <Typography sx={{ width: 80, marginRight: 2 }}>{title}</Typography>
             {sessionsToDisplay.map((session: Session) => (
-                <SessionDraggable key={session.id} session={session} setLocation={setLocation} />
+                <SessionDraggable key={session.id} session={session} setLocation={setLocation} Component={Component} />
             ))}
         </Box>
     )

--- a/src/events/page/schedule/components/SessionDraggable.tsx
+++ b/src/events/page/schedule/components/SessionDraggable.tsx
@@ -1,15 +1,16 @@
 import * as React from 'react'
 import { Session } from '../../../../types'
 import { Box } from '@mui/material'
-import { SessionCardContent } from './SessionCardContent'
+import { SessionCardContent, SessionCardContentProps } from './SessionCardContent'
 import { getSessionBackgroundColor } from './getSessionBackgroundColor'
 import { hexDarken } from '../../../../utils/colors/hexDarken'
 
 export type SessionDraggableProps = {
     session: Session
     setLocation: (to: string) => void
+    Component?: React.ComponentType<SessionCardContentProps>
 }
-export const SessionDraggable = ({ session, setLocation }: SessionDraggableProps) => {
+export const SessionDraggable = ({ session, setLocation, Component = SessionCardContent }: SessionDraggableProps) => {
     const backgroundColor = getSessionBackgroundColor(session)
 
     const hours = Math.floor(session.durationMinutes / 60)
@@ -37,7 +38,7 @@ export const SessionDraggable = ({ session, setLocation }: SessionDraggableProps
                 },
                 background: backgroundColor,
             }}>
-            <SessionCardContent session={session} setLocation={setLocation} />
+            <Component session={session} setLocation={setLocation} />
         </Box>
     )
 }

--- a/src/events/page/schedule/components/TemplateCardContent.tsx
+++ b/src/events/page/schedule/components/TemplateCardContent.tsx
@@ -4,11 +4,11 @@ import { Box, IconButton, Typography } from '@mui/material'
 import DeleteIcon from '@mui/icons-material/Delete'
 import { DEFAULT_SESSION_CARD_BACKGROUND_COLOR } from '../scheduleConstants'
 
-export type SessionCardContentProps = {
+export type TemplateCardContentProps = {
     session: Session
     onDelete?: () => void
 }
-export const TemplateCardContent = ({ session, onDelete }: SessionCardContentProps) => {
+export const TemplateCardContent = ({ session, onDelete }: TemplateCardContentProps) => {
     if (!session.id) {
         return null
     }

--- a/src/events/page/sessions/EventSession.tsx
+++ b/src/events/page/sessions/EventSession.tsx
@@ -34,6 +34,7 @@ export const EventSession = ({ event }: EventSessionProps) => {
     }
 
     const session = sessionResult.data
+    const isSessionInSchedule = session.dates && !!session.dates.start
 
     const goBack = () => navigateBackOrFallbackTo('/sessions', setLocation)
 
@@ -55,6 +56,15 @@ export const EventSession = ({ event }: EventSessionProps) => {
                 <Button color="warning" onClick={() => setDeleteOpen(true)}>
                     Delete session
                 </Button>
+                {isSessionInSchedule && (
+                    <Button
+                        onClick={async () => {
+                            await mutation.mutate({ ...session, dates: null })
+                            sessionResult.load()
+                        }}>
+                        Remove from schedule
+                    </Button>
+                )}
             </Box>
 
             <ConfirmDialog

--- a/src/events/page/sessions/components/SessionsImporterFromConferenceHallDialog.tsx
+++ b/src/events/page/sessions/components/SessionsImporterFromConferenceHallDialog.tsx
@@ -6,6 +6,7 @@ import { ConferenceHallProposal, Event, Format } from '../../../../types'
 import { Dialog, DialogContent, Typography } from '@mui/material'
 import { useNotification } from '../../../../hooks/notificationHook'
 import { addSessionsFromCH } from '../../../actions/sessions/addSessionsFromCH'
+import { UPDATE_FIELDS_SESSIONS } from '../../../actions/conferenceHallUtils/importSessions'
 
 export type SessionsImporterFromConferenceHallProps = {
     event: Event
@@ -41,7 +42,8 @@ export const SessionsImporterFromConferenceHallDialog = ({
                                 submitText="Add sessions"
                             />
                             <Typography margin={1}>
-                                ⚠️ it will replace already added sessions matching the selected one.
+                                ⚠️ it will update or add already added sessions matching the selected one. The update
+                                will only concern those fields: {UPDATE_FIELDS_SESSIONS.join(', ')}
                             </Typography>
                         </>
                     )}


### PR DESCRIPTION
- when adding a session after the event has already a schedule, the "Add sessions" no longer replace the session, it only update some fields, keeping the dates & notes intact. 
- when displaying every day of the event in the schedule, it move to the first day to prevent grey zone 
- fix template picker & add background blur to the picker in the schedule 