### PR TITLE
Speakers company/geolocation/job title stats & fix dev log error for rerender

### DIFF
--- a/src/events/page/sessions/list/EventSessions.tsx
+++ b/src/events/page/sessions/list/EventSessions.tsx
@@ -12,7 +12,7 @@ import {
     Typography,
 } from '@mui/material'
 import * as React from 'react'
-import { useEffect, useState } from 'react'
+import { useMemo, useState } from 'react'
 import { Event, Session } from '../../../../types'
 import { useSessions } from '../../../../services/hooks/useSessions'
 import { FirestoreQueryLoaderAndErrorDisplay } from '../../../../components/FirestoreQueryLoaderAndErrorDisplay'
@@ -33,26 +33,24 @@ export const EventSessions = ({ event }: EventSessionsProps) => {
     const [searchParams, setSearchParams] = useSearchParams()
     const sessions = useSessions(event)
     const [sessionsImportOpen, setSessionsImportOpen] = useState(false)
-    const [displayedSessions, setDisplayedSessions] = useState<Session[]>([])
     const [search, setSearch] = useState<string>('')
     const [selectedCategory, setSelectedCategory] = useState<string>(searchParams.get('category') || '')
     const [selectedFormat, setSelectedFormat] = useState<string>(searchParams.get('format') || '')
     const [onlyWithoutSpeaker, setOnlyWithoutSpeaker] = useState<boolean>(false)
     const [generateDialogOpen, setGenerateDialogOpen] = useState(false)
 
-    const sessionsData = sessions.data || []
-    const isFiltered = displayedSessions.length !== sessionsData.length
+    const sessionsData = useMemo(() => sessions.data || [], [sessions.data])
 
-    useEffect(() => {
-        setDisplayedSessions(
-            filterSessions(sessionsData, {
-                search,
-                category: selectedCategory,
-                format: selectedFormat,
-                withoutSpeaker: onlyWithoutSpeaker,
-            })
-        )
+    const displayedSessions = useMemo(() => {
+        return filterSessions(sessionsData, {
+            search,
+            category: selectedCategory,
+            format: selectedFormat,
+            withoutSpeaker: onlyWithoutSpeaker,
+        })
     }, [sessionsData, search, selectedCategory, selectedFormat, onlyWithoutSpeaker])
+
+    const isFiltered = displayedSessions.length !== sessionsData.length
 
     if (sessions.isLoading) {
         return <FirestoreQueryLoaderAndErrorDisplay hookResult={sessions} />
@@ -89,7 +87,12 @@ export const EventSessions = ({ event }: EventSessionsProps) => {
                                     <InputAdornment position="start">
                                         <IconButton
                                             aria-label="Clear filters"
-                                            onClick={() => setDisplayedSessions(displayedSessions)}
+                                            onClick={() => {
+                                                setSearch('')
+                                                setSearchParams({})
+                                                setSelectedCategory('')
+                                                setSelectedFormat('')
+                                            }}
                                             edge="end">
                                             <Clear />
                                         </IconButton>

--- a/src/events/page/speakers/EventSpeakers.tsx
+++ b/src/events/page/speakers/EventSpeakers.tsx
@@ -1,6 +1,6 @@
 import { Box, Button, Card, Container, Grid, IconButton, InputAdornment, TextField, Typography } from '@mui/material'
 import * as React from 'react'
-import { useEffect, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { Event, Speaker } from '../../../types'
 import { FirestoreQueryLoaderAndErrorDisplay } from '../../../components/FirestoreQueryLoaderAndErrorDisplay'
 import { EventSpeakerItem } from './EventSpeakerItem'
@@ -22,7 +22,7 @@ export const EventSpeakers = ({ event }: EventSpeakersProps) => {
     const [displayedSpeakers, setDisplayedSpeakers] = useState<Speaker[]>([])
     const [search, setSearch] = useState<string>('')
 
-    const speakersData = speakers.data || []
+    const speakersData = useMemo(() => speakers.data || [], [speakers.data])
     const isFiltered = displayedSpeakers.length !== speakersData.length
 
     useEffect(() => {

--- a/src/events/page/speakers/EventSpeakers.tsx
+++ b/src/events/page/speakers/EventSpeakers.tsx
@@ -9,6 +9,7 @@ import { RequireConferenceHallConnections } from '../../../components/RequireCon
 import { SpeakersFromConferenceHallUpdaterDialog } from './components/SpeakersFromConferenceHallUpdaterDialog'
 import { Clear } from '@mui/icons-material'
 import { useSessionsRaw } from '../../../services/hooks/useSessions'
+import { SpeakersStatsDialog } from './components/SpeakersStatsDialog'
 
 export type EventSpeakersProps = {
     event: Event
@@ -17,6 +18,7 @@ export const EventSpeakers = ({ event }: EventSpeakersProps) => {
     const speakers = useSpeakers(event.id)
     const sessions = useSessionsRaw(event.id)
     const [updaterDialogOpen, setUpdaterDialogOpen] = useState(false)
+    const [speakersStatsOpen, setSpeakersStatsOpen] = useState(false)
     const [displayedSpeakers, setDisplayedSpeakers] = useState<Speaker[]>([])
     const [search, setSearch] = useState<string>('')
 
@@ -53,6 +55,7 @@ export const EventSpeakers = ({ event }: EventSpeakersProps) => {
                         Update speakers infos from ConferenceHall
                     </Button>
                 </RequireConferenceHallConnections>
+                <Button onClick={() => setSpeakersStatsOpen(true)}>Speakers stats</Button>
                 <Button href="/speakers/new" variant="contained">
                     Add speaker
                 </Button>
@@ -95,6 +98,16 @@ export const EventSpeakers = ({ event }: EventSpeakersProps) => {
                     onClose={() => {
                         setUpdaterDialogOpen(false)
                     }}
+                />
+            )}
+            {speakersStatsOpen && (
+                <SpeakersStatsDialog
+                    isOpen={speakersStatsOpen}
+                    onClose={() => {
+                        setSpeakersStatsOpen(false)
+                    }}
+                    event={event}
+                    speakers={speakers.data || []}
                 />
             )}
         </Container>

--- a/src/events/page/speakers/components/SpeakersStatsDialog.tsx
+++ b/src/events/page/speakers/components/SpeakersStatsDialog.tsx
@@ -1,0 +1,79 @@
+import { Event, Session, Speaker } from '../../../../types'
+import { Button, CircularProgress, Dialog, DialogContent, Typography } from '@mui/material'
+import * as React from 'react'
+import { GenerationStates, useSessionsGeneration } from '../../../actions/sessions/generation/useSessionsGeneration'
+import { useMemo, useState } from 'react'
+
+export const SpeakersStatsDialog = ({
+    isOpen,
+    onClose,
+    event,
+    speakers,
+}: {
+    isOpen: boolean
+    onClose: () => void
+    event: Event
+    speakers: Speaker[]
+}) => {
+    const stats = useMemo(() => {
+        return {
+            companies: speakers.reduce((acc, speaker) => {
+                if (speaker.company) {
+                    acc[speaker.company] = acc[speaker.company] ? acc[speaker.company] + 1 : 1
+                }
+                return acc
+            }, {} as Record<string, number>),
+            jobTitles: speakers.reduce((acc, speaker) => {
+                if (speaker.jobTitle) {
+                    acc[speaker.jobTitle] = acc[speaker.jobTitle] ? acc[speaker.jobTitle] + 1 : 1
+                }
+                return acc
+            }, {} as Record<string, number>),
+            geolocations: speakers.reduce((acc, speaker) => {
+                if (speaker.geolocation) {
+                    acc[speaker.geolocation] = acc[speaker.geolocation] ? acc[speaker.geolocation] + 1 : 1
+                }
+                return acc
+            }, {} as Record<string, number>),
+        }
+    }, [speakers])
+
+    return (
+        <Dialog open={isOpen} onClose={onClose} maxWidth="lg" fullWidth={true} scroll="body">
+            <DialogContent>
+                <Typography variant="h5">Speakers stats</Typography>
+
+                <Typography variant="h6">Companies ({Object.keys(stats.companies).length})</Typography>
+                <ul>
+                    {Object.entries(stats.companies).map(([company, count]) => (
+                        <li key={company}>
+                            {company} - {count}
+                        </li>
+                    ))}
+                </ul>
+
+                <Typography variant="h6">Job titles ({Object.keys(stats.geolocations).length})</Typography>
+                <ul>
+                    {Object.entries(stats.jobTitles).map(([jobTitle, count]) => (
+                        <li key={jobTitle}>
+                            {jobTitle} - {count}
+                        </li>
+                    ))}
+                </ul>
+
+                <Typography variant="h6">Geolocations ({Object.keys(stats.geolocations).length})</Typography>
+                <ul>
+                    {Object.entries(stats.geolocations).map(([geolocation, count]) => (
+                        <li key={geolocation}>
+                            {geolocation} - {count}
+                        </li>
+                    ))}
+                </ul>
+
+                <Button variant="outlined" onClick={onClose}>
+                    Close
+                </Button>
+            </DialogContent>
+        </Dialog>
+    )
+}

--- a/src/events/page/speakers/components/SpeakersStatsDialog.tsx
+++ b/src/events/page/speakers/components/SpeakersStatsDialog.tsx
@@ -1,8 +1,7 @@
-import { Event, Session, Speaker } from '../../../../types'
-import { Button, CircularProgress, Dialog, DialogContent, Typography } from '@mui/material'
+import { Event, Speaker } from '../../../../types'
+import { Button, Dialog, DialogContent, Typography } from '@mui/material'
 import * as React from 'react'
-import { GenerationStates, useSessionsGeneration } from '../../../actions/sessions/generation/useSessionsGeneration'
-import { useMemo, useState } from 'react'
+import { useMemo } from 'react'
 
 export const SpeakersStatsDialog = ({
     isOpen,


### PR DESCRIPTION
1. Add a speakers statistics dialog that aggregates data by companies, job titles, and geolocations.
2. Resolve development errors related to unnecessary rerendering.