### PR TITLE
Add FAQ in Static API & Improve Update website speed 

### DIFF
--- a/src/events/actions/getFaq.ts
+++ b/src/events/actions/getFaq.ts
@@ -1,0 +1,27 @@
+import { Faq, FaqCategory } from '../../types'
+import { getDocs } from 'firebase/firestore'
+import { collections } from '../../services/firebase'
+import { collection } from '@firebase/firestore'
+
+export const getFaq = async (eventId: string): Promise<FaqCategory[]> => {
+    const snapshots = await getDocs(collections.faq(eventId))
+
+    const faqCategory = snapshots.docs.map((snapshot) => ({
+        ...snapshot.data(),
+    }))
+
+    const faqItems = await Promise.all(faqCategory.map((category) => getFaqItems(eventId, category.id)))
+
+    return faqCategory.map((category, index) => ({
+        ...category,
+        items: faqItems[index] || [],
+    }))
+}
+
+const getFaqItems = async (eventId: string, faqId: string): Promise<Faq[]> => {
+    const snapshots = await getDocs(collection(collections.faq(eventId), `${faqId}/items`))
+
+    return snapshots.docs.map((snapshot) => ({
+        ...(snapshot.data() as Faq),
+    }))
+}

--- a/src/events/actions/updateWebsiteActions/generateStaticJson.ts
+++ b/src/events/actions/updateWebsiteActions/generateStaticJson.ts
@@ -4,14 +4,18 @@ import { getSpeakers } from '../getSpeakers'
 import { getSponsors } from '../getSponsors'
 import { generateOpenFeedbackJson } from './generateOpenFeedbackJson'
 import { getTeam } from '../getTeam'
+import { getFaq } from '../getFaq'
 
 export const generateStaticJson = async (event: Event) => {
-    const [sessions, speakers, sponsors, team] = await Promise.all([
+    const [sessions, speakers, sponsors, team, faq] = await Promise.all([
         getSessions(event.id),
         getSpeakers(event.id),
         getSponsors(event.id),
         getTeam(event.id),
+        getFaq(event.id),
     ])
+
+    const faqPublic = faq.filter((f) => !f.private)
 
     const openFeedbackOutput = generateOpenFeedbackJson(event, sessions, speakers)
 
@@ -102,6 +106,7 @@ export const generateStaticJson = async (event: Event) => {
         sessions: outputSessions,
         sponsors: outputSponsor,
         team: team,
+        faq: faqPublic,
         generatedAt: new Date().toISOString(),
     }
     const outputPrivate = {
@@ -110,6 +115,7 @@ export const generateStaticJson = async (event: Event) => {
         sessions: outputSessionsPrivate,
         sponsors: outputSponsor,
         team: team,
+        faq: faq,
         generatedAt: new Date().toISOString(),
     }
 

--- a/src/events/actions/updateWebsiteActions/generateStaticJson.ts
+++ b/src/events/actions/updateWebsiteActions/generateStaticJson.ts
@@ -6,10 +6,12 @@ import { generateOpenFeedbackJson } from './generateOpenFeedbackJson'
 import { getTeam } from '../getTeam'
 
 export const generateStaticJson = async (event: Event) => {
-    const sessions = await getSessions(event.id)
-    const speakers = await getSpeakers(event.id)
-    const sponsors = await getSponsors(event.id)
-    const team = await getTeam(event.id)
+    const [sessions, speakers, sponsors, team] = await Promise.all([
+        getSessions(event.id),
+        getSpeakers(event.id),
+        getSponsors(event.id),
+        getTeam(event.id),
+    ])
 
     const openFeedbackOutput = generateOpenFeedbackJson(event, sessions, speakers)
 

--- a/src/events/actions/updateWebsiteActions/updateStaticJson.ts
+++ b/src/events/actions/updateWebsiteActions/updateStaticJson.ts
@@ -19,9 +19,14 @@ export const updateStaticJson = async (
     const outputRefPrivate = ref(storage, fileNames.private)
     const outputRefOpenFeedback = ref(storage, fileNames.openfeedback)
 
-    await uploadString(outputRefPublic, JSON.stringify(outputPublic), undefined, metadata)
-    await uploadString(outputRefPrivate, JSON.stringify(outputPrivate), undefined, metadata)
-    await uploadString(outputRefOpenFeedback, JSON.stringify(outputOpenFeedback), undefined, metadata)
+    // noinspection ES6MissingAwait
+    const promiseArray = [
+        uploadString(outputRefPublic, JSON.stringify(outputPublic), undefined, metadata),
+        uploadString(outputRefPrivate, JSON.stringify(outputPrivate), undefined, metadata),
+        uploadString(outputRefOpenFeedback, JSON.stringify(outputOpenFeedback), undefined, metadata),
+    ]
+
+    await Promise.all(promiseArray)
 
     return fileNames
 }


### PR DESCRIPTION
- Add FAQ to Static API (the "private" FAQ only in the private static API), closing #99 
- Improve static api generation speed (parallel await), closing #81 