### PR TITLE
Add sessions export menu & ask user to confirm when a generation is in progress

### DIFF
--- a/src/events/actions/sessions/generation/useSessionsGenerationGeneric.ts
+++ b/src/events/actions/sessions/generation/useSessionsGenerationGeneric.ts
@@ -1,6 +1,7 @@
 import { Event, Session } from '../../../../types'
 import { useCallback, useState } from 'react'
 import { updateSessions } from '../updateSession'
+import { useConfirmBrowserClose } from '../../../../hooks/useConfirmBrowserClose'
 
 export enum GenerationStates {
     IDLE = 'IDLE',
@@ -44,6 +45,8 @@ export const useSessionsGenerationGeneric = <
         message: '',
         results: null,
     })
+
+    useConfirmBrowserClose(state.generationState === GenerationStates.GENERATING, 'Generation in progress')
 
     const generate = useCallback(
         async (

--- a/src/events/page/sessions/list/EventSessions.tsx
+++ b/src/events/page/sessions/list/EventSessions.tsx
@@ -28,6 +28,7 @@ import { FilterFormat } from './FilterFormat'
 import { GenerateSessionsTextContentDialog } from '../components/GenerateSessionsTextContentDialog'
 import { useSearchParams } from '../../../../hooks/useSearchParams'
 import { GenerateSessionsVideoDialog } from '../components/GenerateSessionsVideoDialog'
+import { exportSessionsAction, SessionsExportType } from './actions/exportSessionsActions'
 
 export type EventSessionsProps = {
     event: Event
@@ -41,7 +42,9 @@ export const EventSessions = ({ event }: EventSessionsProps) => {
     const [selectedFormat, setSelectedFormat] = useState<string>(searchParams.get('format') || '')
     const [onlyWithoutSpeaker, setOnlyWithoutSpeaker] = useState<boolean>(false)
     const [generateAnchorEl, setGenerateAnchorEl] = React.useState<null | HTMLElement>(null)
-    const open = Boolean(generateAnchorEl)
+    const isGenerateMenuOpen = Boolean(generateAnchorEl)
+    const [exportAnchorEl, setExportAnchorEl] = React.useState<null | HTMLElement>(null)
+    const isExportMenuOpen = Boolean(exportAnchorEl)
     const [generateTextDialogOpen, setGenerateTextDialogOpen] = useState(false)
     const [generateVideoDialogOpen, setGenerateVideoDialogOpen] = useState(false)
 
@@ -73,6 +76,13 @@ export const EventSessions = ({ event }: EventSessionsProps) => {
         }
     }
 
+    const closeExportMenu = (type: SessionsExportType | null) => () => {
+        setExportAnchorEl(null)
+        if (!type) return
+
+        exportSessionsAction(sessionsData, displayedSessions, type)
+    }
+
     if (sessions.isLoading) {
         return <FirestoreQueryLoaderAndErrorDisplay hookResult={sessions} />
     }
@@ -94,13 +104,23 @@ export const EventSessions = ({ event }: EventSessionsProps) => {
                 <Menu
                     id="basic-menu"
                     anchorEl={generateAnchorEl}
-                    open={open}
+                    open={isGenerateMenuOpen}
                     onClose={closeGenerateMenu('')}
                     MenuListProps={{
                         'aria-labelledby': 'basic-button',
                     }}>
                     <MenuItem onClick={closeGenerateMenu('text')}>Teasing for socials</MenuItem>
                     <MenuItem onClick={closeGenerateMenu('video')}>Teasing video using ShortVid.io</MenuItem>
+                </Menu>
+                <Button onClick={(event) => setExportAnchorEl(event.currentTarget)} endIcon={<ExpandMore />}>
+                    Export
+                </Button>
+                <Menu anchorEl={exportAnchorEl} open={isExportMenuOpen} onClose={closeExportMenu(null)}>
+                    {Object.entries(SessionsExportType).map(([key, value]) => (
+                        <MenuItem key={key} onClick={closeExportMenu(value)}>
+                            {value}
+                        </MenuItem>
+                    ))}
                 </Menu>
                 <Button href="/sessions/new" variant="contained">
                     Add session

--- a/src/events/page/sessions/list/actions/exportSessionsActions.ts
+++ b/src/events/page/sessions/list/actions/exportSessionsActions.ts
@@ -1,0 +1,63 @@
+import { Session } from '../../../../../types'
+import { triggerJsonDownloadFromData } from '../../../../../utils/triggerFileDownload'
+import { downloadJsonToXLSX } from '../../../../../utils/downloadJsonToXLSX'
+import { flattenObject } from '../../../../../utils/flattedObject'
+
+export enum SessionsExportType {
+    AllSessionsXLSX = 'All sessions (XLSX)',
+    AllSessionsJson = 'All sessions (JSON)',
+    DisplayedSessionsXLSX = 'Displayed sessions (XLSX)',
+    DisplayedSessionsJson = 'Displayed sessions (JSON)',
+    TeasingSessionsXLSX = 'Teasing data (XLSX, only displayed)',
+    TeasingSessionsJson = 'Teasing data (JSON, only displayed)',
+}
+
+export const exportSessionsAction = (
+    allSessions: Session[],
+    displayedSessions: Session[],
+    type: SessionsExportType
+) => {
+    const flattenAllSessions = allSessions.map((s) => flattenObject(s))
+    const flattedDisplayedSessions = displayedSessions.map((s) => flattenObject(s))
+    const teasingData = displayedSessions.map((s) => ({
+        title: s.title,
+        speakers: s.speakersData,
+        start: s.dates?.start?.toISO() ?? '',
+        teasingData: s.teasingPosts,
+        teasingImage: s.teaserImageUrl,
+        teasingVideo: s.teaserVideoUrl,
+    }))
+
+    switch (type) {
+        case SessionsExportType.AllSessionsXLSX:
+            downloadJsonToXLSX(flattenAllSessions, 'sessions.xlsx')
+            break
+        case SessionsExportType.AllSessionsJson:
+            const json = JSON.stringify(allSessions, null, 4)
+            const fileName = 'sessions.json'
+            triggerJsonDownloadFromData(json, fileName)
+            break
+        case SessionsExportType.DisplayedSessionsXLSX:
+            downloadJsonToXLSX(flattedDisplayedSessions, 'sessions.xlsx')
+            break
+        case SessionsExportType.DisplayedSessionsJson:
+            const displayedJson = JSON.stringify(displayedSessions, null, 4)
+            const displayedFileName = 'sessions.json'
+            triggerJsonDownloadFromData(displayedJson, displayedFileName)
+            break
+        case SessionsExportType.TeasingSessionsXLSX:
+            downloadJsonToXLSX(
+                teasingData.map((s) => flattenObject(s)),
+                'teasing-sessions.xlsx'
+            )
+            break
+        case SessionsExportType.TeasingSessionsJson:
+            const teasingJson = JSON.stringify(teasingData, null, 4)
+            const teasingFileName = 'teasing-sessions.json'
+            triggerJsonDownloadFromData(teasingJson, teasingFileName)
+            break
+        default:
+            console.warn('Unknown type', type)
+            break
+    }
+}

--- a/src/events/page/speakers/EventSpeakers.tsx
+++ b/src/events/page/speakers/EventSpeakers.tsx
@@ -25,17 +25,10 @@ import { SpeakersStatsDialog } from './components/SpeakersStatsDialog'
 import { useNotification } from '../../../hooks/notificationHook'
 import { downloadJsonToXLSX } from '../../../utils/downloadJsonToXLSX'
 import { triggerJsonDownloadFromData } from '../../../utils/triggerFileDownload'
+import { exportSpeakersAction, SpeakersExportType } from './actions/exportSpeakersAction'
 
 export type EventSpeakersProps = {
     event: Event
-}
-
-enum ExportType {
-    EmailCommaSeparated = 'email-comma',
-    AllXLSX = 'all',
-    AllJson = 'all-json',
-    DisplayedXLSX = 'displayed',
-    DisplayedJson = 'displayed-json',
 }
 
 export const EventSpeakers = ({ event }: EventSpeakersProps) => {
@@ -69,37 +62,12 @@ export const EventSpeakers = ({ event }: EventSpeakersProps) => {
         )
     }, [speakersData, search])
 
-    const closeExportMenu = (type: string) => () => {
+    const closeExportMenu = (type: SpeakersExportType | null) => () => {
         setExportAnchorEl(null)
-        switch (type) {
-            case ExportType.EmailCommaSeparated:
-                const emails = speakersData
-                    .map((s) => s.email)
-                    .filter(Boolean)
-                    .join(', ')
-                navigator.clipboard.writeText(emails)
-                createNotification('Emails copied to clipboard', { type: 'success' })
-                break
-            case ExportType.AllXLSX:
-                downloadJsonToXLSX(speakersData, 'speakers.xlsx')
-                break
-            case ExportType.AllJson:
-                const json = JSON.stringify(speakersData, null, 4)
-                const fileName = 'speakers.json'
-                triggerJsonDownloadFromData(json, fileName)
-                break
-            case ExportType.DisplayedXLSX:
-                downloadJsonToXLSX(displayedSpeakers, 'speakers.xlsx')
-                break
-            case ExportType.DisplayedJson:
-                const displayedJson = JSON.stringify(displayedSpeakers, null, 4)
-                const displayedFileName = 'speakers.json'
-                triggerJsonDownloadFromData(displayedJson, displayedFileName)
-                break
-            default:
-                console.warn('Unknown type', type)
-                break
+        if (!type) {
+            return
         }
+        exportSpeakersAction(speakersData, displayedSpeakers, type, createNotification)
     }
 
     if (speakers.isLoading) {
@@ -123,17 +91,21 @@ export const EventSpeakers = ({ event }: EventSpeakersProps) => {
                     id="basic-menu"
                     anchorEl={exportAnchorEl}
                     open={isExportMenuOpen}
-                    onClose={closeExportMenu('')}
+                    onClose={closeExportMenu(null)}
                     MenuListProps={{
                         'aria-labelledby': 'basic-button',
                     }}>
-                    <MenuItem onClick={closeExportMenu(ExportType.EmailCommaSeparated)}>
+                    <MenuItem onClick={closeExportMenu(SpeakersExportType.EmailCommaSeparated)}>
                         Copy emails (comma separated) to clipboard
                     </MenuItem>
-                    <MenuItem onClick={closeExportMenu(ExportType.AllXLSX)}>All speakers (XLSX)</MenuItem>
-                    <MenuItem onClick={closeExportMenu(ExportType.AllJson)}>All speakers (JSON)</MenuItem>
-                    <MenuItem onClick={closeExportMenu(ExportType.DisplayedXLSX)}>Displayed speakers (XLSX)</MenuItem>
-                    <MenuItem onClick={closeExportMenu(ExportType.DisplayedJson)}>Displayed speakers (JSON)</MenuItem>
+                    <MenuItem onClick={closeExportMenu(SpeakersExportType.AllXLSX)}>All speakers (XLSX)</MenuItem>
+                    <MenuItem onClick={closeExportMenu(SpeakersExportType.AllJson)}>All speakers (JSON)</MenuItem>
+                    <MenuItem onClick={closeExportMenu(SpeakersExportType.DisplayedXLSX)}>
+                        Displayed speakers (XLSX)
+                    </MenuItem>
+                    <MenuItem onClick={closeExportMenu(SpeakersExportType.DisplayedJson)}>
+                        Displayed speakers (JSON)
+                    </MenuItem>
                 </Menu>
                 <Button href="/speakers/new" variant="contained">
                     Add speaker

--- a/src/events/page/speakers/EventSpeakers.tsx
+++ b/src/events/page/speakers/EventSpeakers.tsx
@@ -85,7 +85,7 @@ export const EventSpeakers = ({ event }: EventSpeakersProps) => {
                 </RequireConferenceHallConnections>
                 <Button onClick={() => setSpeakersStatsOpen(true)}>Stats</Button>
                 <Button onClick={(event) => setExportAnchorEl(event.currentTarget)} endIcon={<ExpandMore />}>
-                    Export{' '}
+                    Export
                 </Button>
                 <Menu
                     id="basic-menu"

--- a/src/events/page/speakers/actions/exportSpeakersAction.ts
+++ b/src/events/page/speakers/actions/exportSpeakersAction.ts
@@ -1,0 +1,49 @@
+import { downloadJsonToXLSX } from '../../../../utils/downloadJsonToXLSX'
+import { triggerJsonDownloadFromData } from '../../../../utils/triggerFileDownload'
+import { Speaker } from '../../../../types'
+import { CreateNotificationOption } from '../../../../context/SnackBarProvider'
+
+export enum SpeakersExportType {
+    EmailCommaSeparated = 'email-comma',
+    AllXLSX = 'all',
+    AllJson = 'all-json',
+    DisplayedXLSX = 'displayed',
+    DisplayedJson = 'displayed-json',
+}
+
+export const exportSpeakersAction = (
+    speakers: Speaker[],
+    displayedSpeakers: Speaker[],
+    type: SpeakersExportType,
+    createNotification: (message: string, options?: CreateNotificationOption) => void
+) => {
+    switch (type) {
+        case SpeakersExportType.EmailCommaSeparated:
+            const emails = speakers
+                .map((s) => s.email)
+                .filter(Boolean)
+                .join(', ')
+            navigator.clipboard.writeText(emails)
+            createNotification('Emails copied to clipboard', { type: 'success' })
+            break
+        case SpeakersExportType.AllXLSX:
+            downloadJsonToXLSX(speakers, 'speakers.xlsx')
+            break
+        case SpeakersExportType.AllJson:
+            const json = JSON.stringify(speakers, null, 4)
+            const fileName = 'speakers.json'
+            triggerJsonDownloadFromData(json, fileName)
+            break
+        case SpeakersExportType.DisplayedXLSX:
+            downloadJsonToXLSX(displayedSpeakers, 'speakers.xlsx')
+            break
+        case SpeakersExportType.DisplayedJson:
+            const displayedJson = JSON.stringify(displayedSpeakers, null, 4)
+            const displayedFileName = 'speakers.json'
+            triggerJsonDownloadFromData(displayedJson, displayedFileName)
+            break
+        default:
+            console.warn('Unknown type', type)
+            break
+    }
+}

--- a/src/hooks/useConfirmBrowserClose.ts
+++ b/src/hooks/useConfirmBrowserClose.ts
@@ -1,0 +1,17 @@
+import { useEffect } from 'react'
+
+export const useConfirmBrowserClose = (enable: boolean, message: string) => {
+    useEffect(() => {
+        function beforeUnload(e: BeforeUnloadEvent) {
+            if (!enable) return
+            e.preventDefault()
+            e.returnValue = message
+        }
+
+        window.addEventListener('beforeunload', beforeUnload)
+
+        return () => {
+            window.removeEventListener('beforeunload', beforeUnload)
+        }
+    }, [enable])
+}

--- a/src/utils/flattedObject.ts
+++ b/src/utils/flattedObject.ts
@@ -1,0 +1,33 @@
+interface FlattenedObject {
+    [key: string]: any
+}
+
+export const flattenObject = (obj: any, prefix: string = ''): FlattenedObject => {
+    let result: FlattenedObject = {}
+
+    for (let key in obj) {
+        if (obj.hasOwnProperty(key)) {
+            const value = obj[key]
+            const newKey = prefix ? `${prefix}.${key}` : key
+
+            if (typeof value === 'object' && value !== null) {
+                if (Array.isArray(value)) {
+                    value.forEach((item, index) => {
+                        const arrayKey = `${newKey}[${index}]`
+                        if (typeof item === 'object' && item !== null) {
+                            result = { ...result, ...flattenObject(item, arrayKey) }
+                        } else {
+                            result[arrayKey] = item
+                        }
+                    })
+                } else {
+                    result = { ...result, ...flattenObject(value, newKey) }
+                }
+            } else {
+                result[newKey] = value
+            }
+        }
+    }
+
+    return result
+}


### PR DESCRIPTION
- Add export for sessions: xlsx, json, displayed sessions or all sessions, teasing data (video, text, image) 
- Ask the user to confirm closing the tab if a generation is in progress 