### PR TITLE
New admin interface to follow SaaS usage & fix error not always displayed when loading data

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -7,9 +7,10 @@ service cloud.firestore {
 
         function eventData(eventId) { return get(/databases/$(database)/documents/events/$(eventId)).data; }
         function isAdmin(data) { return data.owner == request.auth.uid || request.auth.uid in data.members;}
+        function isSuperAdmin(userId) { return exists(/databases/$(database)/documents/admins/users/admins/$(userId)); }
 
         match /events/{eventId} {
-            allow read: if authenticated() && isAdmin(resource.data);
+            allow read: if authenticated() && (isAdmin(resource.data) || isSuperAdmin(request.auth.uid));
             allow create: if authenticated();
             allow write: if authenticated() && isAdmin(resource.data);
 
@@ -41,7 +42,12 @@ service cloud.firestore {
                 allow read: if authenticated() && isAdmin(eventData(eventId));
                 allow write: if authenticated() && isAdmin(eventData(eventId));
             }
+        }
 
+        match /admins/users/admins/{userId} {
+        	allow read: if authenticated() && isSuperAdmin(request.auth.uid);
+            allow write: if false;
+            allow create: if false;
         }
 
     }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,6 +12,7 @@ import { NotificationProvider } from './context/SnackBarProvider'
 import { SuspenseLoader } from './components/SuspenseLoader'
 import { PublicApp } from './public/PublicApp'
 import { ForgotPasswordScreen } from './auth/ForgotPasswordScreen'
+import { AdminScreen } from './events/admin/AdminScreen'
 
 const EventsScreen = lazy(() =>
     import('./events/list/EventsScreen').then((module) => ({ default: module.EventsScreen }))
@@ -73,6 +74,11 @@ export const App = ({}) => {
                                     <Route path="/">
                                         <Suspense fallback={<SuspenseLoader />}>
                                             <EventsScreen />
+                                        </Suspense>
+                                    </Route>
+                                    <Route path="/admins">
+                                        <Suspense fallback={<SuspenseLoader />}>
+                                            <AdminScreen />
                                         </Suspense>
                                     </Route>
                                     <Route path="/events/">

--- a/src/events/admin/AdminScreen.tsx
+++ b/src/events/admin/AdminScreen.tsx
@@ -1,0 +1,61 @@
+import * as React from 'react'
+import { useSelector } from 'react-redux'
+import { selectUserIdOpenPlanner } from '../../auth/authReducer'
+import { FirestoreQueryLoaderAndErrorDisplay } from '../../components/FirestoreQueryLoaderAndErrorDisplay'
+import { Box, Button, Container, Typography } from '@mui/material'
+import { useIsAdmin } from '../../services/hooks/useIsAdmin'
+import { useAdminEvents } from '../../services/hooks/useAdminEvents'
+import { DataGrid } from '@mui/x-data-grid'
+import { DateTime } from 'luxon'
+import { EventLayoutAuthUser } from '../list/EventLayoutAuthUser'
+
+export const AdminScreen = ({}) => {
+    const userId = useSelector(selectUserIdOpenPlanner)
+    const events = useAdminEvents()
+    const isAdmin = useIsAdmin(userId)
+
+    const eventsAsRow = (events.data || []).map((event: any) => {
+        return {
+            id: event.id,
+            createdAt: event.createdAt.toDate().toLocaleString(),
+            name: event.name,
+            happenAt: DateTime.fromJSDate(event.dates.start).toRelative(),
+        }
+    })
+
+    const columns = [
+        { field: 'id', headerName: 'ID', width: 90 },
+        { field: 'createdAt', headerName: 'Created At', width: 200 },
+        { field: 'name', headerName: 'Name', width: 200 },
+        { field: 'happenAt', headerName: 'happenAt', width: 200 },
+    ]
+
+    return (
+        <Container component="main" maxWidth="md">
+            <EventLayoutAuthUser />
+            <Typography variant="h1">Admin 🍿</Typography>
+
+            <Button variant="outlined" size="large" href="/">
+                {isAdmin ? 'GO BACK' : 'Not an admin, back off!'}
+            </Button>
+
+            <FirestoreQueryLoaderAndErrorDisplay hookResult={events} />
+
+            <Box sx={{ height: '80vh', width: '100%' }}>
+                <DataGrid
+                    rows={eventsAsRow}
+                    columns={columns}
+                    initialState={{
+                        pagination: {
+                            paginationModel: {
+                                pageSize: 50,
+                            },
+                        },
+                    }}
+                    checkboxSelection
+                    disableRowSelectionOnClick
+                />
+            </Box>
+        </Container>
+    )
+}

--- a/src/events/list/EventLayoutAuthUser.tsx
+++ b/src/events/list/EventLayoutAuthUser.tsx
@@ -1,0 +1,22 @@
+import { Avatar, Box, Button, Typography } from '@mui/material'
+import { logout, selectUserOpenPlanner, UserState } from '../../auth/authReducer'
+import * as React from 'react'
+import { useAppDispatch } from '../../reduxStore'
+import { useSelector } from 'react-redux'
+
+export const EventLayoutAuthUser = () => {
+    const dispatch = useAppDispatch()
+    const user = useSelector(selectUserOpenPlanner) as UserState
+
+    return (
+        <Box display="flex" justifyContent="flex-end" alignItems="flex-end" flexDirection="column" marginTop={1}>
+            <Box display="flex" alignItems="center">
+                <Avatar alt={user.avatarURL} src={user.displayName}></Avatar>
+                <Typography variant="body1" textTransform="capitalize" marginLeft={1}>
+                    {user.displayName}
+                </Typography>
+                <Button onClick={() => dispatch(logout())}>Logout</Button>
+            </Box>
+        </Box>
+    )
+}

--- a/src/events/list/EventsLayout.tsx
+++ b/src/events/list/EventsLayout.tsx
@@ -1,26 +1,14 @@
 import * as React from 'react'
-import { Avatar, Box, Button, Container, Typography } from '@mui/material'
-import { useAppDispatch } from '../../reduxStore'
-import { logout, selectUserOpenPlanner, UserState } from '../../auth/authReducer'
-import { useSelector } from 'react-redux'
+import { Box, Container, Typography } from '@mui/material'
+import { EventLayoutAuthUser } from './EventLayoutAuthUser'
 
 export type EventsLayoutProps = {
     children: React.ReactNode
 }
 export const EventsLayout = ({ children }: EventsLayoutProps) => {
-    const dispatch = useAppDispatch()
-    const user = useSelector(selectUserOpenPlanner) as UserState
     return (
         <Container component="main" maxWidth="md">
-            <Box display="flex" justifyContent="flex-end" alignItems="flex-end" flexDirection="column" marginTop={1}>
-                <Box display="flex" alignItems="center">
-                    <Avatar alt={user.avatarURL} src={user.displayName}></Avatar>
-                    <Typography variant="body1" textTransform="capitalize" marginLeft={1}>
-                        {user.displayName}
-                    </Typography>
-                    <Button onClick={() => dispatch(logout())}>Logout</Button>
-                </Box>
-            </Box>
+            <EventLayoutAuthUser />
 
             <Typography variant="h1">OpenPlanner</Typography>
             <Typography variant="h2">Your events</Typography>

--- a/src/events/list/EventsScreen.tsx
+++ b/src/events/list/EventsScreen.tsx
@@ -12,6 +12,7 @@ import { NewEventFromConferenceHallDialog } from '../new/NewEventFromConferenceH
 import { NewEventCreatedDialog } from '../new/NewEventCreatedDialog'
 import { useNotification } from '../../hooks/notificationHook'
 import { NewEventDialog } from '../new/NewEventDialog'
+import { useIsAdmin } from '../../services/hooks/useIsAdmin'
 
 export const EventsScreen = ({}) => {
     const userId = useSelector(selectUserIdOpenPlanner)
@@ -19,6 +20,7 @@ export const EventsScreen = ({}) => {
     const [newEventCHOpen, setNewEventFromCHOpen] = useState(false)
     const [newEventOpen, setNewEventOpen] = useState(false)
     const [newEventId, setNewEventId] = useState<null | string>(null)
+    const isAdmin = useIsAdmin(userId)
 
     const { createNotification } = useNotification()
 
@@ -51,6 +53,11 @@ export const EventsScreen = ({}) => {
                     <EventsListItem event={event} key={event.id} />
                 ))}
             </Box>
+            {isAdmin && (
+                <Button variant="outlined" size="large" href="/admins">
+                    ADMIN
+                </Button>
+            )}
 
             <NewEventFromConferenceHallDialog isOpen={newEventCHOpen} onClose={onEventCreated} />
             <NewEventDialog isOpen={newEventOpen} onClose={onEventCreated} />

--- a/src/services/converters.ts
+++ b/src/services/converters.ts
@@ -19,6 +19,23 @@ export const eventConverter: FirestoreDataConverter<Event | NewEvent> = {
         return event
     },
 }
+export const event2Converter: FirestoreDataConverter<Event> = {
+    fromFirestore(snapshot): Event {
+        const data = snapshot.data()
+
+        return {
+            id: snapshot.id,
+            ...data,
+            dates: {
+                start: data.dates?.start ? data.dates.start.toDate() : null,
+                end: data.dates?.end ? data.dates.end.toDate() : null,
+            },
+        } as Event
+    },
+    toFirestore(event: Event) {
+        return event
+    },
+}
 
 export const sessionConverter: FirestoreDataConverter<Session> = {
     fromFirestore(snapshot): Session {
@@ -113,6 +130,20 @@ export const faqItemConverter: FirestoreDataConverter<Faq> = {
         } as Faq
     },
     toFirestore(data: Faq) {
+        return data
+    },
+}
+
+export const adminUserConverter: FirestoreDataConverter<{ id: string }> = {
+    fromFirestore(snapshot): { id: string } {
+        const data = snapshot.data()
+
+        return {
+            id: snapshot.id,
+            ...data,
+        }
+    },
+    toFirestore(data: any) {
         return data
     },
 }

--- a/src/services/firebase.ts
+++ b/src/services/firebase.ts
@@ -5,6 +5,7 @@ import { getAuth } from 'firebase/auth'
 import { getStorage } from 'firebase/storage'
 import { Auth } from '@firebase/auth'
 import {
+    adminUserConverter,
     eventConverter,
     faqConverter,
     sessionConverter,
@@ -41,6 +42,8 @@ export const collections = {
         collection(instanceFirestore, 'events', eventId, 'speakers').withConverter(speakerConverter),
     team: (eventId: string) => collection(instanceFirestore, 'events', eventId, 'team').withConverter(teamConverter),
     faq: (eventId: string) => collection(instanceFirestore, 'events', eventId, 'faq').withConverter(faqConverter),
+
+    adminsUsers: collection(instanceFirestore, 'admins', 'users', 'admins').withConverter(adminUserConverter),
 }
 
 export const getOpenPlannerAuth = (): Auth => {

--- a/src/services/hooks/firestoreQueryHook.ts
+++ b/src/services/hooks/firestoreQueryHook.ts
@@ -42,15 +42,31 @@ export const useFirestoreCollection = <T>(query: Query<T>, subscribe: boolean = 
 
         try {
             if (subscribe) {
-                unsubcribeFunc = onSnapshot(query, (querySnapshot) => {
-                    docTransformer(querySnapshot)
-                    setLoading(false)
-                })
+                unsubcribeFunc = onSnapshot(
+                    query,
+                    (querySnapshot) => {
+                        docTransformer(querySnapshot)
+                        setLoading(false)
+                    },
+                    (error) => {
+                        console.log(error)
+                        setError(error.message)
+                        setLoading(false)
+                    }
+                )
             } else {
-                getDocs(query).then((querySnapshot) => {
-                    docTransformer(querySnapshot)
-                    setLoading(false)
-                })
+                getDocs(query)
+                    .then((querySnapshot) => {
+                        docTransformer(querySnapshot)
+                    })
+                    .catch((error) => {
+                        console.log(error)
+                        setLoading(false)
+                        setError(error.message)
+                    })
+                    .finally(() => {
+                        setLoading(false)
+                    })
             }
         } catch (error: any) {
             console.log(error)
@@ -101,15 +117,30 @@ export const useFirestoreDocument = <T>(ref: DocumentReference<T>, subscribe: bo
 
         try {
             if (subscribe) {
-                unsubcribeFunc = onSnapshot(ref, (docSnapshot) => {
-                    docTransformer(docSnapshot)
-                    setLoading(false)
-                })
+                unsubcribeFunc = onSnapshot(
+                    ref,
+                    (docSnapshot) => {
+                        docTransformer(docSnapshot)
+                        setLoading(false)
+                    },
+                    (error) => {
+                        console.log(error)
+                        setError(error.message)
+                        setLoading(false)
+                    }
+                )
             } else {
-                getDoc(ref).then((docSnapshot) => {
-                    docTransformer(docSnapshot)
-                    setLoading(false)
-                })
+                getDoc(ref)
+                    .then((docSnapshot) => {
+                        docTransformer(docSnapshot)
+                    })
+                    .catch((error) => {
+                        console.log(error)
+                        setError(error.message)
+                    })
+                    .finally(() => {
+                        setLoading(false)
+                    })
             }
         } catch (error: any) {
             console.log(error)

--- a/src/services/hooks/useAdminEvents.ts
+++ b/src/services/hooks/useAdminEvents.ts
@@ -1,0 +1,12 @@
+import { collections } from '../firebase'
+import { orderBy, query, QueryConstraint } from '@firebase/firestore'
+import { useFirestoreCollection, UseQueryResult } from './firestoreQueryHook'
+import { Event } from '../../types'
+import { event2Converter } from '../converters'
+
+export const useAdminEvents = (): UseQueryResult<Event[]> => {
+    const constraints: QueryConstraint[] = []
+    constraints.push(orderBy('createdAt', 'desc'))
+
+    return useFirestoreCollection(query(collections.events, ...constraints).withConverter(event2Converter), false)
+}

--- a/src/services/hooks/useIsAdmin.ts
+++ b/src/services/hooks/useIsAdmin.ts
@@ -1,0 +1,17 @@
+import { UserId } from '../../auth/authReducer'
+import { useFirestoreDocument } from './firestoreQueryHook'
+import { doc } from 'firebase/firestore'
+import { collections } from '../firebase'
+
+export const useIsAdmin = (userId: UserId): boolean => {
+    const ref = doc(collections.adminsUsers, userId)
+
+    const results = useFirestoreDocument(ref)
+
+    // noinspection RedundantIfStatementJS
+    if (!results.error && results.data && results.loaded && results.data.id === userId) {
+        return true
+    }
+
+    return false
+}


### PR DESCRIPTION
- add a new UI to follow OpenPlanner usage, restricted to admins (me), changing the firestore.rules
- fix a bug making load error not stored, thus not displayed