### PR TITLE
feat:Ask to delete orphaned speakers when deleting a session

### DIFF
--- a/src/events/page/sessions/DeleteOrphanedSpeakersDialog.tsx
+++ b/src/events/page/sessions/DeleteOrphanedSpeakersDialog.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { Checkbox, DialogContentText, FormControlLabel, List, ListItem } from '@mui/material'
 import { ConfirmDialog } from '../../../components/ConfirmDialog'
 import { Speaker } from '../../../types'
@@ -18,12 +18,21 @@ export const DeleteOrphanedSpeakersDialog = ({
     onClose,
     onAccept,
 }: DeleteOrphanedSpeakersDialogProps) => {
-    const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set(speakers.map((s) => s.id)))
+    const [selectedIds, setSelectedIds] = useState<Set<string>>(
+        () => new Set(speakers.map((s) => s.id)),
+    )
 
-    // Keep selectedIds in sync when speakers list changes
-    if (speakers.length > 0 && selectedIds.size === 0) {
+    // Keep selectedIds in sync when the dialog is opened or the speakers list changes
+    useEffect(() => {
+        if (!open) {
+            // Clear selection when dialog is closed to avoid stale IDs on next open
+            setSelectedIds(new Set())
+            return
+        }
+
+        // When dialog is open, select exactly the current speaker IDs
         setSelectedIds(new Set(speakers.map((s) => s.id)))
-    }
+    }, [open, speakers])
 
     return (
         <ConfirmDialog

--- a/src/events/page/sessions/DeleteOrphanedSpeakersDialog.tsx
+++ b/src/events/page/sessions/DeleteOrphanedSpeakersDialog.tsx
@@ -1,0 +1,68 @@
+import { useState } from 'react'
+import { Checkbox, DialogContentText, FormControlLabel, List, ListItem } from '@mui/material'
+import { ConfirmDialog } from '../../../components/ConfirmDialog'
+import { Speaker } from '../../../types'
+
+export type DeleteOrphanedSpeakersDialogProps = {
+    open: boolean
+    loading: boolean
+    speakers: Speaker[]
+    onClose: () => void
+    onAccept: (speakerIds: string[]) => void
+}
+
+export const DeleteOrphanedSpeakersDialog = ({
+    open,
+    loading,
+    speakers,
+    onClose,
+    onAccept,
+}: DeleteOrphanedSpeakersDialogProps) => {
+    const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set(speakers.map((s) => s.id)))
+
+    // Keep selectedIds in sync when speakers list changes
+    if (speakers.length > 0 && selectedIds.size === 0) {
+        setSelectedIds(new Set(speakers.map((s) => s.id)))
+    }
+
+    return (
+        <ConfirmDialog
+            open={open}
+            title="Delete orphaned speaker(s)?"
+            acceptButton="Delete selected speaker(s)"
+            disabled={loading || selectedIds.size === 0}
+            loading={loading}
+            cancelButton="Keep all"
+            handleClose={onClose}
+            handleAccept={() => onAccept(Array.from(selectedIds))}>
+            <DialogContentText>
+                The following speaker(s) are not linked to any other session. Do you want to delete them?
+            </DialogContentText>
+            <List dense>
+                {speakers.map((speaker) => (
+                    <ListItem key={speaker.id} disablePadding>
+                        <FormControlLabel
+                            control={
+                                <Checkbox
+                                    checked={selectedIds.has(speaker.id)}
+                                    onChange={(e) => {
+                                        setSelectedIds((prev) => {
+                                            const next = new Set(prev)
+                                            if (e.target.checked) {
+                                                next.add(speaker.id)
+                                            } else {
+                                                next.delete(speaker.id)
+                                            }
+                                            return next
+                                        })
+                                    }}
+                                />
+                            }
+                            label={speaker.name}
+                        />
+                    </ListItem>
+                ))}
+            </List>
+        </ConfirmDialog>
+    )
+}

--- a/src/events/page/sessions/DeleteSessionDialog.tsx
+++ b/src/events/page/sessions/DeleteSessionDialog.tsx
@@ -1,0 +1,30 @@
+import { DialogContentText } from '@mui/material'
+import { ConfirmDialog } from '../../../components/ConfirmDialog'
+import { Session } from '../../../types'
+
+export type DeleteSessionDialogProps = {
+    open: boolean
+    loading: boolean
+    session: Session
+    onClose: () => void
+    onAccept: () => void
+}
+
+export const DeleteSessionDialog = ({ open, loading, session, onClose, onAccept }: DeleteSessionDialogProps) => {
+    return (
+        <ConfirmDialog
+            open={open}
+            title="Delete this session?"
+            acceptButton="Delete session"
+            disabled={loading}
+            loading={loading}
+            cancelButton="cancel"
+            handleClose={onClose}
+            handleAccept={onAccept}>
+            <DialogContentText id="alert-dialog-description">
+                {' '}
+                Delete the session {session.title} from this event (not the session's speaker(s))
+            </DialogContentText>
+        </ConfirmDialog>
+    )
+}

--- a/src/events/page/sessions/EventSession.tsx
+++ b/src/events/page/sessions/EventSession.tsx
@@ -1,31 +1,20 @@
 import { useCallback, useState } from 'react'
 import { Event, Speaker } from '../../../types'
-import {
-    Box,
-    Button,
-    Card,
-    Checkbox,
-    Container,
-    DialogContentText,
-    FormControlLabel,
-    List,
-    ListItem,
-    Typography,
-} from '@mui/material'
+import { Box, Button, Card, Container, Typography } from '@mui/material'
 import { useSession } from '../../../services/hooks/useSession'
 import { useLocation, useRoute } from 'wouter'
 import { FirestoreQueryLoaderAndErrorDisplay } from '../../../components/FirestoreQueryLoaderAndErrorDisplay'
 import { ArrowBack } from '@mui/icons-material'
-import { getQueryParams } from '../../../utils/getQuerySearchParameters'
 import { EventSessionForm } from './EventSessionForm'
 import { deleteDoc, doc, getDocs, query, where } from 'firebase/firestore'
 import { collections } from '../../../services/firebase'
-import { ConfirmDialog } from '../../../components/ConfirmDialog'
 import {
     useFirestoreDocumentDeletion,
     useFirestoreDocumentMutation,
 } from '../../../services/hooks/firestoreMutationHooks'
 import { useSpeakersMap } from '../../../services/hooks/useSpeakersMap'
+import { DeleteSessionDialog } from './DeleteSessionDialog'
+import { DeleteOrphanedSpeakersDialog } from './DeleteOrphanedSpeakersDialog'
 
 export type EventSessionProps = {
     event: Event
@@ -41,7 +30,6 @@ export const EventSession = ({ event }: EventSessionProps) => {
     const [orphanedSpeakers, setOrphanedSpeakers] = useState<Speaker[]>([])
     const [orphanDeleteOpen, setOrphanDeleteOpen] = useState(false)
     const [orphanDeleting, setOrphanDeleting] = useState(false)
-    const [selectedOrphanIds, setSelectedOrphanIds] = useState<Set<string>>(new Set())
     const documentDeletion = useFirestoreDocumentDeletion(doc(collections.sessions(event.id), sessionId))
     const mutation = useFirestoreDocumentMutation(doc(collections.sessions(event.id), sessionId))
 
@@ -66,18 +54,21 @@ export const EventSession = ({ event }: EventSessionProps) => {
         [event.id, speakersMap.data]
     )
 
-    const deleteSelectedOrphans = useCallback(async () => {
-        setOrphanDeleting(true)
-        try {
-            for (const speakerId of selectedOrphanIds) {
-                await deleteDoc(doc(collections.speakers(event.id), speakerId))
+    const deleteOrphans = useCallback(
+        async (speakerIds: string[]) => {
+            setOrphanDeleting(true)
+            try {
+                for (const speakerId of speakerIds) {
+                    await deleteDoc(doc(collections.speakers(event.id), speakerId))
+                }
+            } finally {
+                setOrphanDeleting(false)
+                setOrphanDeleteOpen(false)
+                setLocation('/sessions')
             }
-        } finally {
-            setOrphanDeleting(false)
-            setOrphanDeleteOpen(false)
-            setLocation('/sessions')
-        }
-    }, [event.id, selectedOrphanIds])
+        },
+        [event.id]
+    )
 
     if (sessionResult.isLoading || !sessionResult.data) {
         return <FirestoreQueryLoaderAndErrorDisplay hookResult={sessionResult} />
@@ -115,15 +106,12 @@ export const EventSession = ({ event }: EventSessionProps) => {
                 )}
             </Box>
 
-            <ConfirmDialog
+            <DeleteSessionDialog
                 open={deleteOpen}
-                title="Delete this session?"
-                acceptButton="Delete session"
-                disabled={documentDeletion.isLoading}
                 loading={documentDeletion.isLoading}
-                cancelButton="cancel"
-                handleClose={() => setDeleteOpen(false)}
-                handleAccept={async () => {
+                session={session}
+                onClose={() => setDeleteOpen(false)}
+                onAccept={async () => {
                     const speakerIds = session.speakers || []
                     await documentDeletion.mutate()
                     setDeleteOpen(false)
@@ -132,60 +120,24 @@ export const EventSession = ({ event }: EventSessionProps) => {
                         const orphaned = await findOrphanedSpeakers(speakerIds)
                         if (orphaned.length > 0) {
                             setOrphanedSpeakers(orphaned)
-                            setSelectedOrphanIds(new Set(orphaned.map((s) => s.id)))
                             setOrphanDeleteOpen(true)
                             return
                         }
                     }
                     setLocation('/sessions')
-                }}>
-                <DialogContentText id="alert-dialog-description">
-                    {' '}
-                    Delete the session {session.title} from this event (not the session's speaker(s))
-                </DialogContentText>
-            </ConfirmDialog>
+                }}
+            />
 
-            <ConfirmDialog
+            <DeleteOrphanedSpeakersDialog
                 open={orphanDeleteOpen}
-                title="Delete orphaned speaker(s)?"
-                acceptButton="Delete selected speaker(s)"
-                disabled={orphanDeleting || selectedOrphanIds.size === 0}
                 loading={orphanDeleting}
-                cancelButton="Keep all"
-                handleClose={() => {
+                speakers={orphanedSpeakers}
+                onClose={() => {
                     setOrphanDeleteOpen(false)
                     setLocation('/sessions')
                 }}
-                handleAccept={deleteSelectedOrphans}>
-                <DialogContentText>
-                    The following speaker(s) are not linked to any other session. Do you want to delete them?
-                </DialogContentText>
-                <List dense>
-                    {orphanedSpeakers.map((speaker) => (
-                        <ListItem key={speaker.id} disablePadding>
-                            <FormControlLabel
-                                control={
-                                    <Checkbox
-                                        checked={selectedOrphanIds.has(speaker.id)}
-                                        onChange={(e) => {
-                                            setSelectedOrphanIds((prev) => {
-                                                const next = new Set(prev)
-                                                if (e.target.checked) {
-                                                    next.add(speaker.id)
-                                                } else {
-                                                    next.delete(speaker.id)
-                                                }
-                                                return next
-                                            })
-                                        }}
-                                    />
-                                }
-                                label={speaker.name}
-                            />
-                        </ListItem>
-                    ))}
-                </List>
-            </ConfirmDialog>
+                onAccept={deleteOrphans}
+            />
         </Container>
     )
 }

--- a/src/events/page/sessions/EventSession.tsx
+++ b/src/events/page/sessions/EventSession.tsx
@@ -1,19 +1,31 @@
-import { useState } from 'react'
-import { Event } from '../../../types'
-import { Box, Button, Card, Container, DialogContentText, Typography } from '@mui/material'
+import { useCallback, useState } from 'react'
+import { Event, Speaker } from '../../../types'
+import {
+    Box,
+    Button,
+    Card,
+    Checkbox,
+    Container,
+    DialogContentText,
+    FormControlLabel,
+    List,
+    ListItem,
+    Typography,
+} from '@mui/material'
 import { useSession } from '../../../services/hooks/useSession'
 import { useLocation, useRoute } from 'wouter'
 import { FirestoreQueryLoaderAndErrorDisplay } from '../../../components/FirestoreQueryLoaderAndErrorDisplay'
 import { ArrowBack } from '@mui/icons-material'
 import { getQueryParams } from '../../../utils/getQuerySearchParameters'
 import { EventSessionForm } from './EventSessionForm'
-import { doc } from 'firebase/firestore'
+import { deleteDoc, doc, getDocs, query, where } from 'firebase/firestore'
 import { collections } from '../../../services/firebase'
 import { ConfirmDialog } from '../../../components/ConfirmDialog'
 import {
     useFirestoreDocumentDeletion,
     useFirestoreDocumentMutation,
 } from '../../../services/hooks/firestoreMutationHooks'
+import { useSpeakersMap } from '../../../services/hooks/useSpeakersMap'
 
 export type EventSessionProps = {
     event: Event
@@ -24,9 +36,48 @@ export const EventSession = ({ event }: EventSessionProps) => {
 
     const sessionId = params?.sessionId || ''
     const sessionResult = useSession(event.id, sessionId)
+    const speakersMap = useSpeakersMap(event.id)
     const [deleteOpen, setDeleteOpen] = useState(false)
+    const [orphanedSpeakers, setOrphanedSpeakers] = useState<Speaker[]>([])
+    const [orphanDeleteOpen, setOrphanDeleteOpen] = useState(false)
+    const [orphanDeleting, setOrphanDeleting] = useState(false)
+    const [selectedOrphanIds, setSelectedOrphanIds] = useState<Set<string>>(new Set())
     const documentDeletion = useFirestoreDocumentDeletion(doc(collections.sessions(event.id), sessionId))
     const mutation = useFirestoreDocumentMutation(doc(collections.sessions(event.id), sessionId))
+
+    const findOrphanedSpeakers = useCallback(
+        async (speakerIds: string[]) => {
+            const orphaned: Speaker[] = []
+            for (const speakerId of speakerIds) {
+                const sessionsQuery = query(
+                    collections.sessions(event.id),
+                    where('speakers', 'array-contains', speakerId)
+                )
+                const snapshot = await getDocs(sessionsQuery)
+                if (snapshot.empty) {
+                    const speaker = speakersMap.data?.[speakerId]
+                    if (speaker) {
+                        orphaned.push(speaker)
+                    }
+                }
+            }
+            return orphaned
+        },
+        [event.id, speakersMap.data]
+    )
+
+    const deleteSelectedOrphans = useCallback(async () => {
+        setOrphanDeleting(true)
+        try {
+            for (const speakerId of selectedOrphanIds) {
+                await deleteDoc(doc(collections.speakers(event.id), speakerId))
+            }
+        } finally {
+            setOrphanDeleting(false)
+            setOrphanDeleteOpen(false)
+            setLocation('/sessions')
+        }
+    }, [event.id, selectedOrphanIds])
 
     if (sessionResult.isLoading || !sessionResult.data) {
         return <FirestoreQueryLoaderAndErrorDisplay hookResult={sessionResult} />
@@ -73,14 +124,67 @@ export const EventSession = ({ event }: EventSessionProps) => {
                 cancelButton="cancel"
                 handleClose={() => setDeleteOpen(false)}
                 handleAccept={async () => {
+                    const speakerIds = session.speakers || []
                     await documentDeletion.mutate()
                     setDeleteOpen(false)
+
+                    if (speakerIds.length > 0) {
+                        const orphaned = await findOrphanedSpeakers(speakerIds)
+                        if (orphaned.length > 0) {
+                            setOrphanedSpeakers(orphaned)
+                            setSelectedOrphanIds(new Set(orphaned.map((s) => s.id)))
+                            setOrphanDeleteOpen(true)
+                            return
+                        }
+                    }
                     setLocation('/sessions')
                 }}>
                 <DialogContentText id="alert-dialog-description">
                     {' '}
                     Delete the session {session.title} from this event (not the session's speaker(s))
                 </DialogContentText>
+            </ConfirmDialog>
+
+            <ConfirmDialog
+                open={orphanDeleteOpen}
+                title="Delete orphaned speaker(s)?"
+                acceptButton="Delete selected speaker(s)"
+                disabled={orphanDeleting || selectedOrphanIds.size === 0}
+                loading={orphanDeleting}
+                cancelButton="Keep all"
+                handleClose={() => {
+                    setOrphanDeleteOpen(false)
+                    setLocation('/sessions')
+                }}
+                handleAccept={deleteSelectedOrphans}>
+                <DialogContentText>
+                    The following speaker(s) are not linked to any other session. Do you want to delete them?
+                </DialogContentText>
+                <List dense>
+                    {orphanedSpeakers.map((speaker) => (
+                        <ListItem key={speaker.id} disablePadding>
+                            <FormControlLabel
+                                control={
+                                    <Checkbox
+                                        checked={selectedOrphanIds.has(speaker.id)}
+                                        onChange={(e) => {
+                                            setSelectedOrphanIds((prev) => {
+                                                const next = new Set(prev)
+                                                if (e.target.checked) {
+                                                    next.add(speaker.id)
+                                                } else {
+                                                    next.delete(speaker.id)
+                                                }
+                                                return next
+                                            })
+                                        }}
+                                    />
+                                }
+                                label={speaker.name}
+                            />
+                        </ListItem>
+                    ))}
+                </List>
             </ConfirmDialog>
         </Container>
     )

--- a/src/events/page/sessions/EventSession.tsx
+++ b/src/events/page/sessions/EventSession.tsx
@@ -6,7 +6,7 @@ import { useLocation, useRoute } from 'wouter'
 import { FirestoreQueryLoaderAndErrorDisplay } from '../../../components/FirestoreQueryLoaderAndErrorDisplay'
 import { ArrowBack } from '@mui/icons-material'
 import { EventSessionForm } from './EventSessionForm'
-import { deleteDoc, doc, getDocs, query, where } from 'firebase/firestore'
+import { deleteDoc, doc, getDocs, query, where, writeBatch } from 'firebase/firestore'
 import { collections } from '../../../services/firebase'
 import {
     useFirestoreDocumentDeletion,
@@ -57,16 +57,21 @@ export const EventSession = ({ event }: EventSessionProps) => {
         async (speakerIds: string[]) => {
             setOrphanDeleting(true)
             try {
+                const batch = writeBatch(collections.speakers(event.id).firestore)
                 for (const speakerId of speakerIds) {
-                    await deleteDoc(doc(collections.speakers(event.id), speakerId))
+                    const speakerRef = doc(collections.speakers(event.id), speakerId)
+                    batch.delete(speakerRef)
                 }
-            } finally {
-                setOrphanDeleting(false)
+                await batch.commit()
                 setOrphanDeleteOpen(false)
                 setLocation('/sessions')
+            } catch (error) {
+                console.error('Failed to delete orphaned speakers', error)
+            } finally {
+                setOrphanDeleting(false)
             }
         },
-        [event.id]
+        [event.id, setLocation]
     )
 
     if (sessionResult.isLoading || !sessionResult.data) {

--- a/src/events/page/sessions/EventSession.tsx
+++ b/src/events/page/sessions/EventSession.tsx
@@ -118,6 +118,12 @@ export const EventSession = ({ event }: EventSessionProps) => {
                 onAccept={async () => {
                     const speakerIds = session.speakers || []
                     await documentDeletion.mutate()
+
+                    // If the deletion failed, do not proceed to orphan checking or navigation.
+                    if (documentDeletion.isError || documentDeletion.error) {
+                        return
+                    }
+
                     setDeleteOpen(false)
 
                     if (speakerIds.length > 0) {

--- a/src/events/page/sessions/EventSession.tsx
+++ b/src/events/page/sessions/EventSession.tsx
@@ -42,7 +42,7 @@ export const EventSession = ({ event }: EventSessionProps) => {
                 )
                 const snapshot = await getDocs(sessionsQuery)
                 if (snapshot.empty) {
-                    const speaker = speakersData?.[speakerId]
+                    const speaker = speakersData?.find((s) => s.id === speakerId)
                     if (speaker) {
                         orphaned.push(speaker)
                     }

--- a/src/events/page/sessions/EventSession.tsx
+++ b/src/events/page/sessions/EventSession.tsx
@@ -12,7 +12,6 @@ import {
     useFirestoreDocumentDeletion,
     useFirestoreDocumentMutation,
 } from '../../../services/hooks/firestoreMutationHooks'
-import { useSpeakersMap } from '../../../services/hooks/useSpeakersMap'
 import { DeleteSessionDialog } from './DeleteSessionDialog'
 import { DeleteOrphanedSpeakersDialog } from './DeleteOrphanedSpeakersDialog'
 
@@ -25,7 +24,6 @@ export const EventSession = ({ event }: EventSessionProps) => {
 
     const sessionId = params?.sessionId || ''
     const sessionResult = useSession(event.id, sessionId)
-    const speakersMap = useSpeakersMap(event.id)
     const [deleteOpen, setDeleteOpen] = useState(false)
     const [orphanedSpeakers, setOrphanedSpeakers] = useState<Speaker[]>([])
     const [orphanDeleteOpen, setOrphanDeleteOpen] = useState(false)
@@ -36,6 +34,7 @@ export const EventSession = ({ event }: EventSessionProps) => {
     const findOrphanedSpeakers = useCallback(
         async (speakerIds: string[]) => {
             const orphaned: Speaker[] = []
+            const speakersData = sessionResult.data?.speakersData
             for (const speakerId of speakerIds) {
                 const sessionsQuery = query(
                     collections.sessions(event.id),
@@ -43,7 +42,7 @@ export const EventSession = ({ event }: EventSessionProps) => {
                 )
                 const snapshot = await getDocs(sessionsQuery)
                 if (snapshot.empty) {
-                    const speaker = speakersMap.data?.[speakerId]
+                    const speaker = speakersData?.[speakerId]
                     if (speaker) {
                         orphaned.push(speaker)
                     }
@@ -51,7 +50,7 @@ export const EventSession = ({ event }: EventSessionProps) => {
             }
             return orphaned
         },
-        [event.id, speakersMap.data]
+        [event.id, sessionResult.data?.speakersData]
     )
 
     const deleteOrphans = useCallback(


### PR DESCRIPTION
After a session is deleted, check if any of its speakers are not linked to any other session. If orphaned speakers are found, show a dialog with checkboxes letting the user select which ones to delete.

https://claude.ai/code/session_01SdkRECfqLSaJCouvYNPuKB