### PR TITLE
Add emulator-backed test stack for the API

### DIFF
--- a/functions/package.json
+++ b/functions/package.json
@@ -10,6 +10,8 @@
         "logs": "firebase functions:log",
         "apiOnly": "NODE_ENV=development nodemon src/api/index.ts",
         "test": "vitest --dir src",
+        "test:emulator": "firebase emulators:exec --only firestore --project demo-openplanner-test \"vitest run -c vitest.emulator.config.ts\"",
+        "test:all": "npm run test -- run && npm run test:emulator",
         "gcp-build": "node node_modules/puppeteer/install.mjs"
     },
     "engines": {

--- a/functions/src/api/routes/speakers/updateSpeakerPATCH.emulator.test.ts
+++ b/functions/src/api/routes/speakers/updateSpeakerPATCH.emulator.test.ts
@@ -1,0 +1,176 @@
+import { afterEach, beforeAll, beforeEach, describe, expect, test, vi } from 'vitest'
+import fp from 'fastify-plugin'
+import {
+    clearFirestoreEmulator,
+    getEmulatorApp,
+    getSpeaker,
+    seedEvent,
+    seedSpeaker,
+    setupEmulatorEnv,
+} from '../../testUtils/emulator'
+
+setupEmulatorEnv()
+
+vi.mock('../../dao/firebasePlugin', async () => {
+    const fbAdmin = (await import('firebase-admin')).default
+    const projectId = process.env.GCLOUD_PROJECT || 'demo-openplanner-test'
+    if (!process.env.FIRESTORE_EMULATOR_HOST) {
+        process.env.FIRESTORE_EMULATOR_HOST = '127.0.0.1:8080'
+    }
+    process.env.GCLOUD_PROJECT = projectId
+    const existing = fbAdmin.apps.find((a) => a?.name === 'emulator-test')
+    const app = existing ?? fbAdmin.initializeApp({ projectId }, 'emulator-test')
+
+    const setupFirebase = (fastify: any, _opts: any, next: () => void) => {
+        if (!fastify.firebase) {
+            fastify.decorate('firebase', app)
+        }
+        fastify.firebase = app
+        next()
+    }
+
+    return {
+        setupFirebase,
+        firebasePlugin: fp(setupFirebase, { name: 'fastify-firebase' }),
+        getStorageBucketName: () => 'test-bucket',
+    }
+})
+
+const eventId = 'evt-patch-speaker'
+const speakerId = 'spk-1'
+const apiKey = 'test-api-key'
+
+let fastify: any
+
+beforeAll(async () => {
+    const { setupFastify } = await import('../../setupFastify')
+    fastify = setupFastify()
+    await fastify.ready()
+})
+
+beforeEach(async () => {
+    await clearFirestoreEmulator()
+    await seedEvent(eventId, { name: 'Test Event', apiKey })
+})
+
+afterEach(() => {
+    vi.restoreAllMocks()
+})
+
+describe('PATCH /v1/:eventId/speakers/:speakerId', () => {
+    test('returns 401 when apiKey is missing', async () => {
+        await seedSpeaker(eventId, speakerId, { name: 'Original' })
+
+        const res = await fastify.inject({
+            method: 'PATCH',
+            url: `/v1/${eventId}/speakers/${speakerId}`,
+            payload: { name: 'New name' },
+        })
+
+        expect(res.statusCode).toBe(401)
+    })
+
+    test('returns 404 when speaker does not exist', async () => {
+        const res = await fastify.inject({
+            method: 'PATCH',
+            url: `/v1/${eventId}/speakers/missing-speaker?apiKey=${apiKey}`,
+            payload: { name: 'New name' },
+        })
+
+        expect(res.statusCode).toBe(404)
+        expect(res.body).toContain('Speaker not found')
+    })
+
+    test('returns 400 on invalid body type', async () => {
+        await seedSpeaker(eventId, speakerId, { name: 'Original' })
+
+        const res = await fastify.inject({
+            method: 'PATCH',
+            url: `/v1/${eventId}/speakers/${speakerId}?apiKey=${apiKey}`,
+            payload: { socials: 'not-an-array' },
+        })
+
+        expect(res.statusCode).toBe(400)
+    })
+
+    test('updates only the provided fields and preserves others', async () => {
+        await seedSpeaker(eventId, speakerId, {
+            name: 'Original',
+            bio: 'Untouched bio',
+            email: 'orig@example.com',
+        })
+
+        const res = await fastify.inject({
+            method: 'PATCH',
+            url: `/v1/${eventId}/speakers/${speakerId}?apiKey=${apiKey}`,
+            payload: { name: 'Renamed' },
+        })
+
+        expect(res.statusCode).toBe(200)
+        expect(JSON.parse(res.body)).toMatchObject({ success: true })
+
+        const updated = await getSpeaker(eventId, speakerId)
+        expect(updated).toMatchObject({
+            id: speakerId,
+            name: 'Renamed',
+            bio: 'Untouched bio',
+            email: 'orig@example.com',
+        })
+        expect(updated?.updatedAt).toBeDefined()
+    })
+
+    test('deep-merges customFields with existing values', async () => {
+        await seedSpeaker(eventId, speakerId, {
+            name: 'Speaker',
+            customFields: {
+                shirtSize: 'M',
+                vegetarian: true,
+                hasContract: false,
+            },
+        })
+
+        const res = await fastify.inject({
+            method: 'PATCH',
+            url: `/v1/${eventId}/speakers/${speakerId}?apiKey=${apiKey}`,
+            payload: {
+                customFields: {
+                    shirtSize: 'L',
+                    hasContract: true,
+                },
+            },
+        })
+
+        expect(res.statusCode).toBe(200)
+
+        const updated = await getSpeaker(eventId, speakerId)
+        expect(updated?.customFields).toEqual({
+            shirtSize: 'L',
+            vegetarian: true,
+            hasContract: true,
+        })
+    })
+
+    test('socials icon is auto-derived from name when omitted', async () => {
+        await seedSpeaker(eventId, speakerId, { name: 'Speaker' })
+
+        const res = await fastify.inject({
+            method: 'PATCH',
+            url: `/v1/${eventId}/speakers/${speakerId}?apiKey=${apiKey}`,
+            payload: {
+                socials: [{ name: 'Twitter', link: 'https://twitter.com/foo' }],
+            },
+        })
+
+        expect(res.statusCode).toBe(200)
+        const updated = await getSpeaker(eventId, speakerId)
+        expect(updated?.socials).toEqual([{ name: 'Twitter', icon: 'twitter', link: 'https://twitter.com/foo' }])
+    })
+
+    test('seed/get helpers round-trip via the emulator', async () => {
+        // Sanity check the emulator wiring itself.
+        const app = getEmulatorApp()
+        await app.firestore().doc(`events/${eventId}/speakers/extra`).set({ id: 'extra', name: 'X' })
+        const back = await getSpeaker(eventId, 'extra')
+        expect(back).toMatchObject({ id: 'extra', name: 'X' })
+    })
+})

--- a/functions/src/api/routes/speakers/updateSpeakerPATCH.ts
+++ b/functions/src/api/routes/speakers/updateSpeakerPATCH.ts
@@ -33,7 +33,8 @@ export const TypeBoxUpdateSpeaker = Type.Object(
         customFields: Type.Optional(
             Type.Record(
                 Type.String({ maxLength: MAX_STRING_LENGTH }),
-                Type.Union([Type.String({ maxLength: MAX_STRING_LENGTH }), Type.Boolean()])
+                // Boolean first so AJV's type coercion does not stringify true/false values.
+                Type.Union([Type.Boolean(), Type.String({ maxLength: MAX_STRING_LENGTH })])
             )
         ),
     },

--- a/functions/src/api/testUtils/emulator.ts
+++ b/functions/src/api/testUtils/emulator.ts
@@ -1,0 +1,46 @@
+import fb from 'firebase-admin'
+
+export const EMULATOR_HOST = process.env.FIRESTORE_EMULATOR_HOST || '127.0.0.1:8080'
+export const EMULATOR_PROJECT_ID = process.env.GCLOUD_PROJECT || 'demo-openplanner-test'
+
+let cachedApp: fb.app.App | null = null
+
+export const setupEmulatorEnv = (): void => {
+    process.env.FIRESTORE_EMULATOR_HOST = EMULATOR_HOST
+    process.env.GCLOUD_PROJECT = EMULATOR_PROJECT_ID
+    process.env.GOOGLE_CLOUD_PROJECT = EMULATOR_PROJECT_ID
+}
+
+export const getEmulatorApp = (): fb.app.App => {
+    setupEmulatorEnv()
+    if (cachedApp) return cachedApp
+    const existing = fb.apps.find((a) => a?.name === 'emulator-test') as fb.app.App | undefined
+    cachedApp = existing ?? fb.initializeApp({ projectId: EMULATOR_PROJECT_ID }, 'emulator-test')
+    return cachedApp
+}
+
+export const clearFirestoreEmulator = async (): Promise<void> => {
+    setupEmulatorEnv()
+    const url = `http://${EMULATOR_HOST}/emulator/v1/projects/${EMULATOR_PROJECT_ID}/databases/(default)/documents`
+    const res = await fetch(url, { method: 'DELETE' })
+    if (!res.ok) {
+        throw new Error(`Failed to clear firestore emulator (${res.status}): ${await res.text()}`)
+    }
+}
+
+export const seedDoc = async (path: string, data: Record<string, unknown>): Promise<void> => {
+    await getEmulatorApp().firestore().doc(path).set(data)
+}
+
+export const getDoc = async (path: string): Promise<FirebaseFirestore.DocumentData | null> => {
+    const snap = await getEmulatorApp().firestore().doc(path).get()
+    return snap.exists ? snap.data() ?? null : null
+}
+
+export const seedEvent = (eventId: string, data: Record<string, unknown> = {}) =>
+    seedDoc(`events/${eventId}`, { id: eventId, ...data })
+
+export const seedSpeaker = (eventId: string, speakerId: string, data: Record<string, unknown> = {}) =>
+    seedDoc(`events/${eventId}/speakers/${speakerId}`, { id: speakerId, ...data })
+
+export const getSpeaker = (eventId: string, speakerId: string) => getDoc(`events/${eventId}/speakers/${speakerId}`)

--- a/functions/vitest.config.ts
+++ b/functions/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+    test: {
+        include: ['src/**/*.test.ts'],
+        exclude: ['src/**/*.emulator.test.ts', 'node_modules/**', 'lib/**'],
+    },
+})

--- a/functions/vitest.emulator.config.ts
+++ b/functions/vitest.emulator.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+    test: {
+        include: ['src/**/*.emulator.test.ts'],
+        exclude: ['node_modules/**', 'lib/**'],
+        // Single fork to avoid concurrent writes against the same Firestore emulator project.
+        pool: 'forks',
+        poolOptions: {
+            forks: {
+                singleFork: true,
+            },
+        },
+        testTimeout: 20000,
+        hookTimeout: 20000,
+    },
+})


### PR DESCRIPTION
## Summary

Set up a vitest-based test stack for the API that runs against the Firebase Firestore emulator (in addition to the existing mocked unit tests).

- New helpers in `functions/src/api/testUtils/emulator.ts` to bootstrap a firebase-admin app pointed at the Firestore emulator, clear data between tests, and seed/read documents.
- Split vitest configs:
  - `vitest.config.ts` — default, excludes `*.emulator.test.ts` (existing mocked suite continues to run on `npm test`).
  - `vitest.emulator.config.ts` — targets `*.emulator.test.ts`, single-fork pool to serialize Firestore writes.
- New scripts:
  - `npm run test:emulator` — runs the suite via `firebase emulators:exec --only firestore --project demo-openplanner-test`.
  - `npm run test:all` — runs both suites in sequence.
- First emulator-backed test covers `PATCH /v1/:eventId/speakers/:speakerId`: auth, validation, partial update, customFields deep-merge, social icon derivation.
- Bug fix surfaced by the new test: reordered the `customFields` value union to `[Boolean, String]` so AJV body validation no longer stringifies booleans.

## How to run

Requires Java (Firestore emulator). On macOS with homebrew openjdk: `export PATH=\"/opt/homebrew/opt/openjdk/bin:\$PATH\"`.

```
cd functions
npm run test           # mocked unit tests
npm run test:emulator  # emulator-backed integration tests
npm run test:all       # both
```

## Adding more emulator tests

1. Create `*.emulator.test.ts` next to the route under test.
2. Top of file: `setupEmulatorEnv()` then `vi.mock('../../dao/firebasePlugin', ...)` factory that decorates fastify with the emulator admin app (see the speaker test for the template).
3. Use `clearFirestoreEmulator()` in `beforeEach`, then `seedEvent` / `seedSpeaker` / `seedDoc` helpers.
4. Assert the result via `getSpeaker` / `getDoc` after the request.

## Test plan

- [ ] `npm run test` passes (existing 21 mocked tests, no behavior change).
- [ ] `npm run test:emulator` passes (7 new tests, requires Java for the Firestore emulator).

🤖 Generated with [Claude Code](https://claude.com/claude-code)