### PR TITLE
Add unit tests for the API routes (except pdf/)

### DIFF
--- a/functions/src/api/routes/bupher/bupherChannelsRoute.test.ts
+++ b/functions/src/api/routes/bupher/bupherChannelsRoute.test.ts
@@ -1,0 +1,30 @@
+import { afterEach, describe, expect, test, vi } from 'vitest'
+import { setupFastify } from '../../setupFastify'
+
+vi.mock('../../dao/firebasePlugin', async (importOriginal) => {
+    const mod = await importOriginal<typeof import('../../dao/firebasePlugin')>()
+    return {
+        ...mod,
+        setupFirebase: vi.fn().mockImplementation((_fastify, _options, next) => next()),
+        getStorageBucketName: () => 'test-bucket',
+    }
+})
+
+const eventId = 'evt-1'
+
+describe('GET /v1/:eventId/bupher/channels', () => {
+    const fastify = setupFastify()
+
+    afterEach(() => {
+        vi.restoreAllMocks()
+    })
+
+    test('returns 401 if apiKey is missing', async () => {
+        const res = await fastify.inject({
+            method: 'GET',
+            url: `/v1/${eventId}/bupher/channels`,
+        })
+        expect(res.statusCode).toBe(401)
+        expect(JSON.parse(res.body)).toMatchObject({ error: 'Unauthorized! Du balai !' })
+    })
+})

--- a/functions/src/api/routes/bupher/bupherDraftPostRoute.test.ts
+++ b/functions/src/api/routes/bupher/bupherDraftPostRoute.test.ts
@@ -1,0 +1,30 @@
+import { afterEach, describe, expect, test, vi } from 'vitest'
+import { setupFastify } from '../../setupFastify'
+
+vi.mock('../../dao/firebasePlugin', async (importOriginal) => {
+    const mod = await importOriginal<typeof import('../../dao/firebasePlugin')>()
+    return {
+        ...mod,
+        setupFirebase: vi.fn().mockImplementation((_fastify, _options, next) => next()),
+        getStorageBucketName: () => 'test-bucket',
+    }
+})
+
+const eventId = 'evt-1'
+
+describe('POST /v1/:eventId/bupher/draft-post', () => {
+    const fastify = setupFastify()
+
+    afterEach(() => {
+        vi.restoreAllMocks()
+    })
+
+    test('returns 401 if apiKey is missing', async () => {
+        const res = await fastify.inject({
+            method: 'POST',
+            url: `/v1/${eventId}/bupher/draft-post`,
+        })
+        expect(res.statusCode).toBe(401)
+        expect(JSON.parse(res.body)).toMatchObject({ error: 'Unauthorized! Du balai !' })
+    })
+})

--- a/functions/src/api/routes/bupher/bupherLoginRoute.test.ts
+++ b/functions/src/api/routes/bupher/bupherLoginRoute.test.ts
@@ -1,0 +1,50 @@
+import { afterEach, describe, expect, test, vi } from 'vitest'
+import { setupFastify } from '../../setupFastify'
+
+vi.mock('../../dao/firebasePlugin', async (importOriginal) => {
+    const mod = await importOriginal<typeof import('../../dao/firebasePlugin')>()
+    return {
+        ...mod,
+        setupFirebase: vi.fn().mockImplementation((_fastify, _options, next) => next()),
+        getStorageBucketName: () => 'test-bucket',
+    }
+})
+
+const eventId = 'evt-1'
+
+describe('POST /v1/:eventId/bupher/login', () => {
+    const fastify = setupFastify()
+
+    afterEach(() => {
+        vi.restoreAllMocks()
+    })
+
+    test('returns 401 if apiKey is missing', async () => {
+        const res = await fastify.inject({
+            method: 'POST',
+            url: `/v1/${eventId}/bupher/login`,
+            payload: { email: 'a@b.com', password: 'pw' },
+        })
+        expect(res.statusCode).toBe(401)
+        expect(JSON.parse(res.body)).toMatchObject({ error: 'Unauthorized! Du balai !' })
+    })
+
+    test('returns 400 if body is missing', async () => {
+        const res = await fastify.inject({
+            method: 'POST',
+            url: `/v1/${eventId}/bupher/login`,
+        })
+        expect(res.statusCode).toBe(400)
+        expect(JSON.parse(res.body)).toMatchObject({ error: 'FST_ERR_VALIDATION' })
+    })
+
+    test('returns 400 if body fields are missing', async () => {
+        const res = await fastify.inject({
+            method: 'POST',
+            url: `/v1/${eventId}/bupher/login`,
+            payload: { email: 'a@b.com' },
+        })
+        expect(res.statusCode).toBe(400)
+        expect(JSON.parse(res.body)).toMatchObject({ error: 'FST_ERR_VALIDATION' })
+    })
+})

--- a/functions/src/api/routes/bupher/bupherScheduledPostsRoute.test.ts
+++ b/functions/src/api/routes/bupher/bupherScheduledPostsRoute.test.ts
@@ -1,0 +1,30 @@
+import { afterEach, describe, expect, test, vi } from 'vitest'
+import { setupFastify } from '../../setupFastify'
+
+vi.mock('../../dao/firebasePlugin', async (importOriginal) => {
+    const mod = await importOriginal<typeof import('../../dao/firebasePlugin')>()
+    return {
+        ...mod,
+        setupFirebase: vi.fn().mockImplementation((_fastify, _options, next) => next()),
+        getStorageBucketName: () => 'test-bucket',
+    }
+})
+
+const eventId = 'evt-1'
+
+describe('GET /v1/:eventId/bupher/scheduled-posts', () => {
+    const fastify = setupFastify()
+
+    afterEach(() => {
+        vi.restoreAllMocks()
+    })
+
+    test('returns 401 if apiKey is missing', async () => {
+        const res = await fastify.inject({
+            method: 'GET',
+            url: `/v1/${eventId}/bupher/scheduled-posts`,
+        })
+        expect(res.statusCode).toBe(401)
+        expect(JSON.parse(res.body)).toMatchObject({ error: 'Unauthorized! Du balai !' })
+    })
+})

--- a/functions/src/api/routes/deploy/deploy.test.ts
+++ b/functions/src/api/routes/deploy/deploy.test.ts
@@ -1,0 +1,66 @@
+import { afterEach, describe, expect, test, vi } from 'vitest'
+import { setupFastify } from '../../setupFastify'
+import { EventDao } from '../../dao/eventDao'
+import { Event } from '../../../types'
+
+vi.mock('../../dao/firebasePlugin', async (importOriginal) => {
+    const mod = await importOriginal<typeof import('../../dao/firebasePlugin')>()
+    return {
+        ...mod,
+        setupFirebase: vi.fn().mockImplementation((_fastify, _options, next) => next()),
+        getStorageBucketName: () => 'test-bucket',
+    }
+})
+
+vi.mock('./updateWebsiteActions/updateWebsiteTriggerWebhooksAction', () => ({
+    updateWebsiteTriggerWebhooksActionInternal: vi.fn(() => Promise.resolve()),
+}))
+
+const eventId = 'evt-1'
+const apiKey = 'xxx'
+
+describe('POST /v1/:eventId/deploy', () => {
+    const fastify = setupFastify()
+
+    afterEach(() => {
+        vi.restoreAllMocks()
+    })
+
+    test('returns 401 if apiKey is missing', async () => {
+        const res = await fastify.inject({
+            method: 'POST',
+            url: `/v1/${eventId}/deploy`,
+        })
+        expect(res.statusCode).toBe(401)
+        expect(JSON.parse(res.body)).toMatchObject({ error: 'Unauthorized! Du balai !' })
+    })
+
+    test('returns 200 on happy path', async () => {
+        vi.spyOn(EventDao, 'getEvent').mockResolvedValue({
+            id: eventId,
+            apiKey,
+        } as Event)
+
+        const res = await fastify.inject({
+            method: 'POST',
+            url: `/v1/${eventId}/deploy?apiKey=${apiKey}`,
+        })
+
+        expect(res.statusCode).toBe(200)
+        expect(JSON.parse(res.body)).toMatchObject({
+            success: true,
+        })
+    })
+
+    test('returns 400 when EventDao.getEvent throws', async () => {
+        vi.spyOn(EventDao, 'getEvent').mockRejectedValue(new Error('boom'))
+
+        const res = await fastify.inject({
+            method: 'POST',
+            url: `/v1/${eventId}/deploy?apiKey=${apiKey}`,
+        })
+
+        expect(res.statusCode).toBe(400)
+        expect(JSON.parse(res.body)).toMatchObject({ success: false })
+    })
+})

--- a/functions/src/api/routes/deploy/getDeployFiles.test.ts
+++ b/functions/src/api/routes/deploy/getDeployFiles.test.ts
@@ -1,0 +1,76 @@
+import { afterEach, describe, expect, test, vi } from 'vitest'
+import { setupFastify } from '../../setupFastify'
+import { EventDao } from '../../dao/eventDao'
+import { Event } from '../../../types'
+
+vi.mock('../../dao/firebasePlugin', async (importOriginal) => {
+    const mod = await importOriginal<typeof import('../../dao/firebasePlugin')>()
+    return {
+        ...mod,
+        setupFirebase: vi.fn().mockImplementation((_fastify, _options, next) => next()),
+        getStorageBucketName: () => 'test-bucket',
+    }
+})
+
+vi.mock('./updateWebsiteActions/getFilesNames', () => ({
+    getUploadFilePathFromEvent: vi.fn(() =>
+        Promise.resolve({
+            public: 'public/openplanner.json',
+            private: 'private/private.json',
+            openfeedback: 'openfeedback.json',
+            imageFolder: 'images/',
+            voxxrin: null,
+            pdf: null,
+        })
+    ),
+}))
+
+const eventId = 'evt-1'
+const apiKey = 'xxx'
+
+describe('GET /v1/:eventId/deploy/files', () => {
+    const fastify = setupFastify()
+
+    afterEach(() => {
+        vi.restoreAllMocks()
+    })
+
+    test('returns 401 if apiKey is missing', async () => {
+        const res = await fastify.inject({
+            method: 'GET',
+            url: `/v1/${eventId}/deploy/files`,
+        })
+        expect(res.statusCode).toBe(401)
+        expect(JSON.parse(res.body)).toMatchObject({ error: 'Unauthorized! Du balai !' })
+    })
+
+    test('returns 200 on happy path', async () => {
+        vi.spyOn(EventDao, 'getEvent').mockResolvedValue({
+            id: eventId,
+            apiKey,
+        } as Event)
+
+        const res = await fastify.inject({
+            method: 'GET',
+            url: `/v1/${eventId}/deploy/files?apiKey=${apiKey}`,
+        })
+
+        expect(res.statusCode).toBe(200)
+        expect(JSON.parse(res.body)).toMatchObject({
+            success: true,
+            public: 'public/openplanner.json',
+        })
+    })
+
+    test('returns 400 when getEvent throws', async () => {
+        vi.spyOn(EventDao, 'getEvent').mockRejectedValue(new Error('boom'))
+
+        const res = await fastify.inject({
+            method: 'GET',
+            url: `/v1/${eventId}/deploy/files?apiKey=${apiKey}`,
+        })
+
+        expect(res.statusCode).toBe(400)
+        expect(JSON.parse(res.body)).toMatchObject({ success: false })
+    })
+})

--- a/functions/src/api/routes/event/getEvent.test.ts
+++ b/functions/src/api/routes/event/getEvent.test.ts
@@ -1,0 +1,64 @@
+import { afterEach, describe, expect, test, vi } from 'vitest'
+import { setupFastify } from '../../setupFastify'
+import { EventDao } from '../../dao/eventDao'
+import { Event } from '../../../types'
+
+vi.mock('../../dao/firebasePlugin', async (importOriginal) => {
+    const mod = await importOriginal<typeof import('../../dao/firebasePlugin')>()
+    return {
+        ...mod,
+        setupFirebase: vi.fn().mockImplementation((_fastify, _options, next) => next()),
+        getStorageBucketName: () => 'test-bucket',
+    }
+})
+
+const eventId = 'evt-1'
+
+describe('GET /v1/:eventId/event', () => {
+    const fastify = setupFastify()
+
+    afterEach(() => {
+        vi.restoreAllMocks()
+    })
+
+    test('returns 401 if event is not public', async () => {
+        vi.spyOn(EventDao, 'getEvent').mockResolvedValue({
+            id: eventId,
+            name: 'Test',
+            publicEnabled: false,
+        } as Event)
+
+        const res = await fastify.inject({ method: 'get', url: `/v1/${eventId}/event` })
+        expect(res.statusCode).toBe(401)
+        expect(res.body).toContain('Event is not public')
+    })
+
+    test('returns 401 if public file is missing', async () => {
+        vi.spyOn(EventDao, 'getEvent').mockResolvedValue({
+            id: eventId,
+            name: 'Test',
+            publicEnabled: true,
+            files: null,
+        } as unknown as Event)
+
+        const res = await fastify.inject({ method: 'get', url: `/v1/${eventId}/event` })
+        expect(res.statusCode).toBe(401)
+        expect(res.body).toContain('Missing public file')
+    })
+
+    test('returns 200 with event name and storage URL', async () => {
+        vi.spyOn(EventDao, 'getEvent').mockResolvedValue({
+            id: eventId,
+            name: 'Test Event',
+            publicEnabled: true,
+            files: { public: 'public/openplanner.json' },
+        } as unknown as Event)
+
+        const res = await fastify.inject({ method: 'get', url: `/v1/${eventId}/event` })
+        expect(res.statusCode).toBe(200)
+        expect(JSON.parse(res.body)).toMatchObject({
+            eventName: 'Test Event',
+            dataUrl: 'https://storage.googleapis.com/test-bucket/public/openplanner.json',
+        })
+    })
+})

--- a/functions/src/api/routes/faq/faq.test.ts
+++ b/functions/src/api/routes/faq/faq.test.ts
@@ -1,0 +1,114 @@
+import { afterEach, describe, expect, test, vi } from 'vitest'
+import { setupFastify } from '../../setupFastify'
+import { getMockedFirestore } from '../../testUtils/mockedFirestore'
+import { Event } from '../../../types'
+import { EventDao } from '../../dao/eventDao'
+import { FaqDao } from '../../dao/faqDao'
+
+vi.mock('../../dao/firebasePlugin', async (importOriginal) => {
+    const mod = await importOriginal<typeof import('../../dao/firebasePlugin')>()
+    return {
+        ...mod,
+        setupFirebase: vi.fn().mockImplementation((_fastify, _options, next) => next()),
+    }
+})
+
+const eventId = 'evt-1'
+const apiKey = 'xxx'
+
+describe('FAQ routes', () => {
+    const fastify = setupFastify()
+
+    afterEach(() => {
+        vi.restoreAllMocks()
+    })
+
+    test('POST /v1/:eventId/faq returns 401 without apiKey', async () => {
+        const res = await fastify.inject({
+            method: 'POST',
+            url: `/v1/${eventId}/faq`,
+            payload: {
+                categoryId: 'cat-1',
+                question: 'Q?',
+                answer: 'A',
+                order: 0,
+                categoryOrder: 0,
+            },
+        })
+        expect(res.statusCode).toBe(401)
+    })
+
+    test('POST /v1/:eventId/faq returns 400 on invalid body', async () => {
+        vi.spyOn(fastify.firebase, 'firestore').mockImplementation(() =>
+            getMockedFirestore({ id: eventId, apiKey } as Partial<Event>)
+        )
+
+        const res = await fastify.inject({
+            method: 'POST',
+            url: `/v1/${eventId}/faq?apiKey=${apiKey}`,
+            payload: { categoryId: 'cat-1' },
+        })
+        expect(res.statusCode).toBe(400)
+        expect(JSON.parse(res.body)).toMatchObject({ error: 'FST_ERR_VALIDATION' })
+    })
+
+    test('POST /v1/:eventId/faq creates a question', async () => {
+        vi.spyOn(fastify.firebase, 'firestore').mockImplementation(() =>
+            getMockedFirestore({ id: eventId, apiKey } as Partial<Event>)
+        )
+        const addSpy = vi.spyOn(FaqDao, 'addFaqQuestion').mockResolvedValue('faq-id-1')
+
+        const payload = {
+            categoryId: 'cat-1',
+            categoryName: 'General',
+            question: 'Q?',
+            answer: 'A',
+            order: 1,
+            categoryOrder: 1,
+        }
+
+        const res = await fastify.inject({
+            method: 'POST',
+            url: `/v1/${eventId}/faq?apiKey=${apiKey}`,
+            payload,
+        })
+        expect(res.statusCode).toBe(201)
+        expect(JSON.parse(res.body)).toMatchObject({ faqItemId: 'faq-id-1' })
+        expect(addSpy).toHaveBeenCalledWith(fastify.firebase, eventId, payload)
+    })
+
+    test('GET /v1/:eventId/faq/:faqPrivateId returns categories with their questions', async () => {
+        vi.spyOn(EventDao, 'getEvent').mockResolvedValue({
+            id: eventId,
+            name: 'Test Event',
+        } as Event)
+        vi.spyOn(FaqDao, 'getFaqPrivateCategory').mockResolvedValue([
+            { id: 'cat-1', name: 'General', order: 1, share: true },
+        ])
+        vi.spyOn(FaqDao, 'getFaqQuestions').mockResolvedValue([
+            {
+                id: 'q-1',
+                categoryId: 'cat-1',
+                question: 'Q?',
+                answer: 'A',
+                order: 1,
+                categoryOrder: 1,
+            },
+        ])
+
+        const res = await fastify.inject({
+            method: 'GET',
+            url: `/v1/${eventId}/faq/private-id-1`,
+        })
+        expect(res.statusCode).toBe(200)
+        const body = JSON.parse(res.body)
+        expect(body.eventName).toBe('Test Event')
+        expect(body.faq).toHaveLength(1)
+        expect(body.faq[0].category.id).toBe('cat-1')
+        expect(body.faq[0].questions[0]).toMatchObject({
+            id: 'q-1',
+            categoryId: 'cat-1',
+            categoryName: 'General',
+        })
+    })
+})

--- a/functions/src/api/routes/file/addFilePOST.test.ts
+++ b/functions/src/api/routes/file/addFilePOST.test.ts
@@ -1,0 +1,47 @@
+import { afterEach, describe, expect, test, vi } from 'vitest'
+import { setupFastify } from '../../setupFastify'
+import { getMockedFirestore } from '../../testUtils/mockedFirestore'
+import { Event } from '../../../types'
+
+vi.mock('../../dao/firebasePlugin', async (importOriginal) => {
+    const mod = await importOriginal<typeof import('../../dao/firebasePlugin')>()
+    return {
+        ...mod,
+        setupFirebase: vi.fn().mockImplementation((_fastify, _options, next) => next()),
+        getStorageBucketName: () => 'test-bucket',
+    }
+})
+
+const eventId = 'evt-1'
+const apiKey = 'xxx'
+
+describe('POST /v1/:eventId/files', () => {
+    const fastify = setupFastify()
+
+    afterEach(() => {
+        vi.restoreAllMocks()
+    })
+
+    test('returns 401 if apiKey is missing', async () => {
+        const res = await fastify.inject({
+            method: 'POST',
+            url: `/v1/${eventId}/files`,
+            payload: {},
+        })
+        expect(res.statusCode).toBe(401)
+        expect(JSON.parse(res.body)).toMatchObject({ error: 'Unauthorized! Du balai !' })
+    })
+
+    test('returns 400 when no multipart payload is provided', async () => {
+        vi.spyOn(fastify.firebase, 'firestore').mockImplementation(() => {
+            return getMockedFirestore({ id: eventId, apiKey } as Partial<Event>)
+        })
+
+        const res = await fastify.inject({
+            method: 'POST',
+            url: `/v1/${eventId}/files?apiKey=${apiKey}`,
+            payload: {},
+        })
+        expect(res.statusCode).toBe(400)
+    })
+})

--- a/functions/src/api/routes/file/downloadAndReuploadFilePOST.test.ts
+++ b/functions/src/api/routes/file/downloadAndReuploadFilePOST.test.ts
@@ -1,0 +1,76 @@
+import { afterEach, describe, expect, test, vi } from 'vitest'
+import { setupFastify } from '../../setupFastify'
+import { getMockedFirestore } from '../../testUtils/mockedFirestore'
+import { Event } from '../../../types'
+
+vi.mock('../../dao/firebasePlugin', async (importOriginal) => {
+    const mod = await importOriginal<typeof import('../../dao/firebasePlugin')>()
+    return {
+        ...mod,
+        setupFirebase: vi.fn().mockImplementation((_fastify, _options, next) => next()),
+        getStorageBucketName: () => 'test-bucket',
+    }
+})
+
+const eventId = 'evt-1'
+const apiKey = 'xxx'
+
+describe('POST /v1/:eventId/files/download-reupload', () => {
+    const fastify = setupFastify()
+
+    afterEach(() => {
+        vi.restoreAllMocks()
+    })
+
+    test('returns 401 if apiKey is missing', async () => {
+        const res = await fastify.inject({
+            method: 'POST',
+            url: `/v1/${eventId}/files/download-reupload`,
+            payload: { url: 'https://example.com/file.png' },
+        })
+        expect(res.statusCode).toBe(401)
+        expect(JSON.parse(res.body)).toMatchObject({ error: 'Unauthorized! Du balai !' })
+    })
+
+    test('returns 400 when url is missing', async () => {
+        vi.spyOn(fastify.firebase, 'firestore').mockImplementation(() => {
+            return getMockedFirestore({ id: eventId, apiKey } as Partial<Event>)
+        })
+
+        const res = await fastify.inject({
+            method: 'POST',
+            url: `/v1/${eventId}/files/download-reupload?apiKey=${apiKey}`,
+            payload: {},
+        })
+        expect(res.statusCode).toBe(400)
+        expect(JSON.parse(res.body)).toMatchObject({ error: 'FST_ERR_VALIDATION' })
+    })
+
+    test('returns 400 when fetch returns non-ok response', async () => {
+        vi.spyOn(fastify.firebase, 'firestore').mockImplementation(() => {
+            return getMockedFirestore({ id: eventId, apiKey } as Partial<Event>)
+        })
+
+        const fetchSpy = vi.fn(() =>
+            Promise.resolve({
+                ok: false,
+                status: 404,
+                statusText: 'Not Found',
+            } as Response)
+        )
+        const originalFetch = globalThis.fetch
+        globalThis.fetch = fetchSpy as unknown as typeof globalThis.fetch
+
+        try {
+            const res = await fastify.inject({
+                method: 'POST',
+                url: `/v1/${eventId}/files/download-reupload?apiKey=${apiKey}`,
+                payload: { url: 'https://example.com/missing.png' },
+            })
+            expect(res.statusCode).toBe(400)
+            expect(res.body).toContain('Failed to download file')
+        } finally {
+            globalThis.fetch = originalFetch
+        }
+    })
+})

--- a/functions/src/api/routes/hello/hello.test.ts
+++ b/functions/src/api/routes/hello/hello.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, test, vi } from 'vitest'
+import { setupFastify } from '../../setupFastify'
+
+vi.mock('../../dao/firebasePlugin', async (importOriginal) => {
+    const mod = await importOriginal<typeof import('../../dao/firebasePlugin')>()
+    return {
+        ...mod,
+        setupFirebase: vi.fn().mockImplementation((_fastify, _options, next) => next()),
+    }
+})
+
+describe('GET /hello', () => {
+    const fastify = setupFastify()
+
+    test('returns hello world payload', async () => {
+        const res = await fastify.inject({ method: 'get', url: '/hello' })
+        expect(res.statusCode).toBe(200)
+        expect(JSON.parse(res.body).hello).toMatch(/^world /)
+    })
+})

--- a/functions/src/api/routes/sessions/sessions.test.ts
+++ b/functions/src/api/routes/sessions/sessions.test.ts
@@ -1,0 +1,75 @@
+import { afterEach, describe, expect, test, vi } from 'vitest'
+import { setupFastify } from '../../setupFastify'
+import { getMockedFirestore } from '../../testUtils/mockedFirestore'
+import { Event } from '../../../types'
+
+vi.mock('../../dao/firebasePlugin', async (importOriginal) => {
+    const mod = await importOriginal<typeof import('../../dao/firebasePlugin')>()
+    return {
+        ...mod,
+        setupFirebase: vi.fn().mockImplementation((_fastify, _options, next) => next()),
+        getStorageBucketName: () => 'test-bucket',
+    }
+})
+
+const eventId = 'evt-1'
+const sessionId = 'sess-1'
+const apiKey = 'xxx'
+
+const validBody = {
+    shortVidType: 'announcement',
+    updateSession: false,
+    settings: {
+        backgroundColor: '#000',
+        title: 'Title',
+        startingDate: '2024-01-01',
+        logoUrl: 'https://example.com/logo.png',
+        location: 'Paris',
+        speakers: [],
+    },
+}
+
+describe('POST /v1/:eventId/sessions/:sessionId/shortvid', () => {
+    const fastify = setupFastify()
+
+    afterEach(() => {
+        vi.restoreAllMocks()
+    })
+
+    test('returns 401 if apiKey is missing', async () => {
+        const res = await fastify.inject({
+            method: 'POST',
+            url: `/v1/${eventId}/sessions/${sessionId}/shortvid`,
+            payload: validBody,
+        })
+        expect(res.statusCode).toBe(401)
+        expect(JSON.parse(res.body)).toMatchObject({ error: 'Unauthorized! Du balai !' })
+    })
+
+    test('returns 400 if body is missing', async () => {
+        vi.spyOn(fastify.firebase, 'firestore').mockImplementation(() => {
+            return getMockedFirestore({ id: eventId, apiKey } as Partial<Event>)
+        })
+
+        const res = await fastify.inject({
+            method: 'POST',
+            url: `/v1/${eventId}/sessions/${sessionId}/shortvid?apiKey=${apiKey}`,
+        })
+        expect(res.statusCode).toBe(400)
+        expect(JSON.parse(res.body)).toMatchObject({ error: 'FST_ERR_VALIDATION' })
+    })
+
+    test('returns 400 if body is incomplete', async () => {
+        vi.spyOn(fastify.firebase, 'firestore').mockImplementation(() => {
+            return getMockedFirestore({ id: eventId, apiKey } as Partial<Event>)
+        })
+
+        const res = await fastify.inject({
+            method: 'POST',
+            url: `/v1/${eventId}/sessions/${sessionId}/shortvid?apiKey=${apiKey}`,
+            payload: { shortVidType: 'x' },
+        })
+        expect(res.statusCode).toBe(400)
+        expect(JSON.parse(res.body)).toMatchObject({ error: 'FST_ERR_VALIDATION' })
+    })
+})

--- a/functions/src/api/routes/speakers/updateSpeakerPATCH.test.ts
+++ b/functions/src/api/routes/speakers/updateSpeakerPATCH.test.ts
@@ -1,0 +1,217 @@
+import { afterEach, describe, expect, test, vi } from 'vitest'
+import { setupFastify } from '../../setupFastify'
+import { Event, Speaker } from '../../../types'
+
+vi.mock('../../dao/firebasePlugin', async (importOriginal) => {
+    const mod = await importOriginal<typeof import('../../dao/firebasePlugin')>()
+    return {
+        ...mod,
+        setupFirebase: vi.fn().mockImplementation((fastify, _options, next) => {
+            next()
+        }),
+    }
+})
+
+const eventId = 'evt-1'
+const speakerId = 'spk-1'
+const apiKey = 'xxx'
+
+type MockOptions = {
+    eventApiKey?: string | null
+    speakerExists?: boolean
+    speakerData?: Partial<Speaker>
+    setSpy?: ReturnType<typeof vi.fn>
+    speakerGetError?: unknown
+}
+
+const mockFirestore = ({
+    eventApiKey = apiKey,
+    speakerExists = true,
+    speakerData = { id: speakerId, name: 'Original' },
+    setSpy = vi.fn(() => Promise.resolve({})),
+    speakerGetError,
+}: MockOptions = {}) => {
+    const speakersPath = `events/${eventId}/speakers`
+    return {
+        firestore: () =>
+            ({
+                collection: vi.fn((path: string) => ({
+                    doc: vi.fn(() => ({
+                        get: vi.fn(() => {
+                            if (path === 'events') {
+                                return Promise.resolve({
+                                    exists: true,
+                                    data: () =>
+                                        ({
+                                            id: eventId,
+                                            apiKey: eventApiKey,
+                                        } as Partial<Event>),
+                                })
+                            }
+                            if (path === speakersPath) {
+                                if (speakerGetError) return Promise.reject(speakerGetError)
+                                return Promise.resolve({
+                                    exists: speakerExists,
+                                    data: () => (speakerExists ? speakerData : undefined),
+                                })
+                            }
+                            return Promise.resolve({ exists: false, data: () => undefined })
+                        }),
+                        set: setSpy,
+                    })),
+                })),
+            } as unknown as FirebaseFirestore.Firestore),
+        setSpy,
+    }
+}
+
+describe('PATCH /v1/:eventId/speakers/:speakerId', () => {
+    const fastify = setupFastify()
+
+    afterEach(() => {
+        vi.restoreAllMocks()
+    })
+
+    test('returns 401 if apiKey is missing', async () => {
+        const res = await fastify.inject({
+            method: 'PATCH',
+            url: `/v1/${eventId}/speakers/${speakerId}`,
+            payload: { name: 'New name' },
+        })
+        expect(res.statusCode).toBe(401)
+        expect(JSON.parse(res.body)).toMatchObject({ error: 'Unauthorized! Du balai !' })
+    })
+
+    test('returns 400 if body type is invalid', async () => {
+        const { firestore } = mockFirestore()
+        vi.spyOn(fastify.firebase, 'firestore').mockImplementation(firestore)
+
+        const res = await fastify.inject({
+            method: 'PATCH',
+            url: `/v1/${eventId}/speakers/${speakerId}?apiKey=${apiKey}`,
+            payload: { socials: 'not-an-array' },
+        })
+
+        expect(res.statusCode).toBe(400)
+        expect(JSON.parse(res.body)).toMatchObject({ error: 'FST_ERR_VALIDATION' })
+    })
+
+    test('returns 404 when speaker does not exist', async () => {
+        const { firestore } = mockFirestore({ speakerExists: false })
+        vi.spyOn(fastify.firebase, 'firestore').mockImplementation(firestore)
+
+        const res = await fastify.inject({
+            method: 'PATCH',
+            url: `/v1/${eventId}/speakers/${speakerId}?apiKey=${apiKey}`,
+            payload: { name: 'New name' },
+        })
+
+        expect(res.statusCode).toBe(404)
+        expect(res.body).toContain('Speaker not found')
+    })
+
+    test('writes only the provided fields with merge:true and adds updatedAt', async () => {
+        const setSpy = vi.fn(() => Promise.resolve({}))
+        const { firestore } = mockFirestore({ setSpy })
+        vi.spyOn(fastify.firebase, 'firestore').mockImplementation(firestore)
+
+        const res = await fastify.inject({
+            method: 'PATCH',
+            url: `/v1/${eventId}/speakers/${speakerId}?apiKey=${apiKey}`,
+            payload: { name: 'Renamed' },
+        })
+
+        expect(res.statusCode).toBe(200)
+        expect(JSON.parse(res.body)).toMatchObject({ success: true })
+        expect(setSpy).toHaveBeenCalledTimes(1)
+        expect(setSpy).toHaveBeenCalledWith(
+            {
+                name: 'Renamed',
+                updatedAt: expect.any(Object),
+            },
+            { merge: true }
+        )
+    })
+
+    test('deep-merges customFields with values present on the existing speaker', async () => {
+        const setSpy = vi.fn(() => Promise.resolve({}))
+        const { firestore } = mockFirestore({
+            setSpy,
+            speakerData: {
+                id: speakerId,
+                customFields: {
+                    shirtSize: 'M',
+                    diet: 'vegetarian',
+                    teamLead: 'alice',
+                },
+            },
+        })
+        vi.spyOn(fastify.firebase, 'firestore').mockImplementation(firestore)
+
+        const res = await fastify.inject({
+            method: 'PATCH',
+            url: `/v1/${eventId}/speakers/${speakerId}?apiKey=${apiKey}`,
+            payload: {
+                customFields: {
+                    shirtSize: 'L',
+                    teamLead: 'bob',
+                },
+            },
+        })
+
+        expect(res.statusCode).toBe(200)
+        expect(setSpy).toHaveBeenCalledWith(
+            {
+                customFields: {
+                    shirtSize: 'L',
+                    diet: 'vegetarian',
+                    teamLead: 'bob',
+                },
+                updatedAt: expect.any(Object),
+            },
+            { merge: true }
+        )
+    })
+
+    test('derives the social icon from the name when omitted', async () => {
+        const setSpy = vi.fn(() => Promise.resolve({}))
+        const { firestore } = mockFirestore({ setSpy })
+        vi.spyOn(fastify.firebase, 'firestore').mockImplementation(firestore)
+
+        const res = await fastify.inject({
+            method: 'PATCH',
+            url: `/v1/${eventId}/speakers/${speakerId}?apiKey=${apiKey}`,
+            payload: {
+                socials: [{ name: 'Twitter', link: 'https://twitter.com/foo' }],
+            },
+        })
+
+        expect(res.statusCode).toBe(200)
+        expect(setSpy).toHaveBeenCalledWith(
+            {
+                socials: [{ name: 'Twitter', icon: 'twitter', link: 'https://twitter.com/foo' }],
+                updatedAt: expect.any(Object),
+            },
+            { merge: true }
+        )
+    })
+
+    test('returns 400 when the firestore read fails', async () => {
+        const setSpy = vi.fn(() => Promise.resolve({}))
+        const { firestore } = mockFirestore({
+            setSpy,
+            speakerGetError: new Error('boom'),
+        })
+        vi.spyOn(fastify.firebase, 'firestore').mockImplementation(firestore)
+
+        const res = await fastify.inject({
+            method: 'PATCH',
+            url: `/v1/${eventId}/speakers/${speakerId}?apiKey=${apiKey}`,
+            payload: { name: 'New name' },
+        })
+
+        expect(res.statusCode).toBe(400)
+        expect(res.body).toContain('Failed to update speaker')
+        expect(setSpy).not.toHaveBeenCalled()
+    })
+})

--- a/functions/src/api/routes/sponsors/addJobPostPOST.test.ts
+++ b/functions/src/api/routes/sponsors/addJobPostPOST.test.ts
@@ -1,0 +1,130 @@
+import { afterEach, describe, expect, test, vi } from 'vitest'
+import { setupFastify } from '../../setupFastify'
+import { Event } from '../../../types'
+import { EventDao } from '../../dao/eventDao'
+import { JobPostDao } from '../../dao/jobPostDao'
+import { SponsorDao } from '../../dao/sponsorDao'
+
+vi.mock('../../dao/firebasePlugin', async (importOriginal) => {
+    const mod = await importOriginal<typeof import('../../dao/firebasePlugin')>()
+    return {
+        ...mod,
+        setupFirebase: vi.fn().mockImplementation((fastify, _options, next) => {
+            next()
+        }),
+    }
+})
+
+const eventId = 'evt-1'
+const validJobBody = {
+    sponsorId: 'spk-1',
+    title: 'Senior Dev',
+    description: 'Build cool stuff',
+    location: 'Paris',
+    externalLink: 'https://jobs.test/1',
+    category: 'Software Developer',
+}
+
+const fastify = setupFastify()
+
+describe('POST /v1/:eventId/sponsors/jobPosts (private id)', () => {
+    afterEach(() => {
+        vi.restoreAllMocks()
+    })
+
+    test('returns 401 when addJobPostEnabled is false', async () => {
+        vi.spyOn(EventDao, 'getEvent').mockResolvedValue({
+            id: eventId,
+            addJobPostEnabled: false,
+            addJobPostPrivateId: 'priv-1',
+        } as unknown as Event)
+
+        const res = await fastify.inject({
+            method: 'POST',
+            url: `/v1/${eventId}/sponsors/jobPosts`,
+            payload: { ...validJobBody, addJobPostPrivateId: 'priv-1' },
+        })
+
+        expect(res.statusCode).toBe(401)
+        expect(res.body).toContain('Job posting is not enabled')
+    })
+
+    test('returns 401 when addJobPostPrivateId does not match', async () => {
+        vi.spyOn(EventDao, 'getEvent').mockResolvedValue({
+            id: eventId,
+            addJobPostEnabled: true,
+            addJobPostPrivateId: 'priv-1',
+        } as unknown as Event)
+
+        const res = await fastify.inject({
+            method: 'POST',
+            url: `/v1/${eventId}/sponsors/jobPosts`,
+            payload: { ...validJobBody, addJobPostPrivateId: 'wrong' },
+        })
+
+        expect(res.statusCode).toBe(401)
+        expect(res.body).toContain('Invalid addJobPostPrivateId')
+    })
+
+    test('returns 201 on happy path', async () => {
+        vi.spyOn(EventDao, 'getEvent').mockResolvedValue({
+            id: eventId,
+            addJobPostEnabled: true,
+            addJobPostPrivateId: 'priv-1',
+        } as unknown as Event)
+        const addSpy = vi.spyOn(JobPostDao, 'addJobPost').mockResolvedValue('jp-id')
+
+        const res = await fastify.inject({
+            method: 'POST',
+            url: `/v1/${eventId}/sponsors/jobPosts`,
+            payload: { ...validJobBody, addJobPostPrivateId: 'priv-1' },
+        })
+
+        expect(res.statusCode).toBe(201)
+        expect(JSON.parse(res.body)).toMatchObject({ jobPostId: 'jp-id' })
+        expect(addSpy).toHaveBeenCalledTimes(1)
+    })
+})
+
+describe('POST /v1/:eventId/sponsors/job-posts (sponsor token)', () => {
+    afterEach(() => {
+        vi.restoreAllMocks()
+    })
+
+    test('returns 401 when sponsor token is invalid', async () => {
+        vi.spyOn(SponsorDao, 'findSponsorByToken').mockResolvedValue(null)
+
+        const res = await fastify.inject({
+            method: 'POST',
+            url: `/v1/${eventId}/sponsors/job-posts`,
+            payload: { ...validJobBody, sponsorToken: 'bad-token' },
+        })
+
+        expect(res.statusCode).toBe(401)
+        expect(res.body).toContain('Invalid sponsor token')
+    })
+
+    test('returns 201 and attaches sponsorId on happy path', async () => {
+        vi.spyOn(SponsorDao, 'findSponsorByToken').mockResolvedValue({
+            sponsor: { id: 'spk-1', name: 'Acme' } as any,
+            categoryId: 'cat-1',
+        })
+        const addSpy = vi.spyOn(JobPostDao, 'addJobPost').mockResolvedValue('jp-id')
+
+        const res = await fastify.inject({
+            method: 'POST',
+            url: `/v1/${eventId}/sponsors/job-posts`,
+            payload: { ...validJobBody, sponsorToken: 'good-token' },
+        })
+
+        expect(res.statusCode).toBe(201)
+        expect(JSON.parse(res.body)).toMatchObject({ jobPostId: 'jp-id' })
+        expect(addSpy).toHaveBeenCalledTimes(1)
+        const callArgs = addSpy.mock.calls[0][2]
+        expect(callArgs).toMatchObject({
+            sponsorId: 'spk-1',
+            title: validJobBody.title,
+        })
+        expect((callArgs as any).sponsorToken).toBeUndefined()
+    })
+})

--- a/functions/src/api/routes/sponsors/addSponsorsPOST.test.ts
+++ b/functions/src/api/routes/sponsors/addSponsorsPOST.test.ts
@@ -1,0 +1,91 @@
+import { afterEach, describe, expect, test, vi } from 'vitest'
+import { setupFastify } from '../../setupFastify'
+import { getMockedFirestore } from '../../testUtils/mockedFirestore'
+import { Event } from '../../../types'
+import { SponsorDao } from '../../dao/sponsorDao'
+
+vi.mock('../../dao/firebasePlugin', async (importOriginal) => {
+    const mod = await importOriginal<typeof import('../../dao/firebasePlugin')>()
+    return {
+        ...mod,
+        setupFirebase: vi.fn().mockImplementation((fastify, _options, next) => {
+            next()
+        }),
+    }
+})
+
+describe('POST /v1/:eventId/sponsors', () => {
+    const eventId = 'evt-1'
+    const apiKey = 'xxx'
+    const fastify = setupFastify()
+
+    afterEach(() => {
+        vi.restoreAllMocks()
+    })
+
+    test('returns 401 if apiKey is missing', async () => {
+        const res = await fastify.inject({
+            method: 'POST',
+            url: `/v1/${eventId}/sponsors`,
+            payload: {
+                name: 'Acme',
+                categoryId: 'cat-1',
+                categoryName: 'Gold',
+            },
+        })
+        expect(res.statusCode).toBe(401)
+        expect(JSON.parse(res.body)).toMatchObject({ error: 'Unauthorized! Du balai !' })
+    })
+
+    test('returns 400 if required body field is missing', async () => {
+        vi.spyOn(fastify.firebase, 'firestore').mockImplementation(() => {
+            return getMockedFirestore({ id: eventId, apiKey } as Partial<Event>)
+        })
+
+        const res = await fastify.inject({
+            method: 'POST',
+            url: `/v1/${eventId}/sponsors?apiKey=${apiKey}`,
+            payload: {
+                // missing name
+                categoryId: 'cat-1',
+                categoryName: 'Gold',
+            },
+        })
+        expect(res.statusCode).toBe(400)
+        expect(JSON.parse(res.body)).toMatchObject({ error: 'FST_ERR_VALIDATION' })
+    })
+
+    test('returns 201 with sponsor and category info on happy path', async () => {
+        vi.spyOn(fastify.firebase, 'firestore').mockImplementation(() => {
+            return getMockedFirestore({ id: eventId, apiKey } as Partial<Event>)
+        })
+
+        const addSpy = vi.spyOn(SponsorDao, 'addSponsor').mockResolvedValue('spk-id')
+        const getSpy = vi.spyOn(SponsorDao, 'getSponsor').mockResolvedValue({
+            id: 'spk-id',
+            name: 'Acme',
+            logoUrl: '',
+            website: 'https://acme.test',
+        } as any)
+
+        const res = await fastify.inject({
+            method: 'POST',
+            url: `/v1/${eventId}/sponsors?apiKey=${apiKey}`,
+            payload: {
+                name: 'Acme',
+                categoryId: 'cat-1',
+                categoryName: 'Gold',
+                website: 'https://acme.test',
+            },
+        })
+
+        expect(res.statusCode).toBe(201)
+        expect(JSON.parse(res.body)).toMatchObject({
+            name: 'Acme',
+            categoryId: 'cat-1',
+            categoryName: 'Gold',
+        })
+        expect(addSpy).toHaveBeenCalledTimes(1)
+        expect(getSpy).toHaveBeenCalledTimes(1)
+    })
+})

--- a/functions/src/api/routes/sponsors/approveJobPostPUT.test.ts
+++ b/functions/src/api/routes/sponsors/approveJobPostPUT.test.ts
@@ -1,0 +1,71 @@
+import { afterEach, describe, expect, test, vi } from 'vitest'
+import { setupFastify } from '../../setupFastify'
+import { getMockedFirestore } from '../../testUtils/mockedFirestore'
+import { Event } from '../../../types'
+import { JobPostDao } from '../../dao/jobPostDao'
+import { JobStatus } from '../../../../../src/constants/jobStatus'
+
+vi.mock('../../dao/firebasePlugin', async (importOriginal) => {
+    const mod = await importOriginal<typeof import('../../dao/firebasePlugin')>()
+    return {
+        ...mod,
+        setupFirebase: vi.fn().mockImplementation((fastify, _options, next) => {
+            next()
+        }),
+    }
+})
+
+describe('PUT /v1/:eventId/sponsors/jobPosts/:jobPostId/approval', () => {
+    const eventId = 'evt-1'
+    const jobPostId = 'jp-1'
+    const apiKey = 'xxx'
+    const fastify = setupFastify()
+
+    afterEach(() => {
+        vi.restoreAllMocks()
+    })
+
+    test('returns 401 if apiKey is missing', async () => {
+        const res = await fastify.inject({
+            method: 'PUT',
+            url: `/v1/${eventId}/sponsors/jobPosts/${jobPostId}/approval`,
+            payload: { status: JobStatus.APPROVED },
+        })
+        expect(res.statusCode).toBe(401)
+        expect(JSON.parse(res.body)).toMatchObject({ error: 'Unauthorized! Du balai !' })
+    })
+
+    test('returns 404 when job post does not exist', async () => {
+        vi.spyOn(fastify.firebase, 'firestore').mockImplementation(() => {
+            return getMockedFirestore({ id: eventId, apiKey } as Partial<Event>)
+        })
+        vi.spyOn(JobPostDao, 'getJobPost').mockRejectedValue(new Error('Job post not found'))
+
+        const res = await fastify.inject({
+            method: 'PUT',
+            url: `/v1/${eventId}/sponsors/jobPosts/${jobPostId}/approval?apiKey=${apiKey}`,
+            payload: { status: JobStatus.APPROVED },
+        })
+
+        expect(res.statusCode).toBe(404)
+        expect(res.body).toContain('Job post not found')
+    })
+
+    test('returns 200 and calls setJobPostStatus with status on happy path', async () => {
+        vi.spyOn(fastify.firebase, 'firestore').mockImplementation(() => {
+            return getMockedFirestore({ id: eventId, apiKey } as Partial<Event>)
+        })
+        vi.spyOn(JobPostDao, 'getJobPost').mockResolvedValue({ id: jobPostId } as any)
+        const setSpy = vi.spyOn(JobPostDao, 'setJobPostStatus').mockResolvedValue(true)
+
+        const res = await fastify.inject({
+            method: 'PUT',
+            url: `/v1/${eventId}/sponsors/jobPosts/${jobPostId}/approval?apiKey=${apiKey}`,
+            payload: { status: JobStatus.APPROVED },
+        })
+
+        expect(res.statusCode).toBe(200)
+        expect(JSON.parse(res.body)).toMatchObject({ success: true })
+        expect(setSpy).toHaveBeenCalledWith(fastify.firebase, eventId, jobPostId, JobStatus.APPROVED)
+    })
+})

--- a/functions/src/api/routes/sponsors/deleteJobPostDELETE.test.ts
+++ b/functions/src/api/routes/sponsors/deleteJobPostDELETE.test.ts
@@ -1,0 +1,136 @@
+import { afterEach, describe, expect, test, vi } from 'vitest'
+import { setupFastify } from '../../setupFastify'
+import { getMockedFirestore } from '../../testUtils/mockedFirestore'
+import { Event } from '../../../types'
+import { JobPostDao } from '../../dao/jobPostDao'
+import { SponsorDao } from '../../dao/sponsorDao'
+
+vi.mock('../../dao/firebasePlugin', async (importOriginal) => {
+    const mod = await importOriginal<typeof import('../../dao/firebasePlugin')>()
+    return {
+        ...mod,
+        setupFirebase: vi.fn().mockImplementation((fastify, _options, next) => {
+            next()
+        }),
+    }
+})
+
+const eventId = 'evt-1'
+const jobPostId = 'jp-1'
+const apiKey = 'xxx'
+
+const fastify = setupFastify()
+
+describe('DELETE /v1/:eventId/sponsors/jobPosts/:jobPostId (apiKey)', () => {
+    afterEach(() => {
+        vi.restoreAllMocks()
+    })
+
+    test('returns 401 if apiKey is missing', async () => {
+        const res = await fastify.inject({
+            method: 'DELETE',
+            url: `/v1/${eventId}/sponsors/jobPosts/${jobPostId}`,
+        })
+        expect(res.statusCode).toBe(401)
+        expect(JSON.parse(res.body)).toMatchObject({ error: 'Unauthorized! Du balai !' })
+    })
+
+    test('returns 404 when getJobPost throws', async () => {
+        vi.spyOn(fastify.firebase, 'firestore').mockImplementation(() => {
+            return getMockedFirestore({ id: eventId, apiKey } as Partial<Event>)
+        })
+        vi.spyOn(JobPostDao, 'getJobPost').mockRejectedValue(new Error('Job post not found'))
+
+        const res = await fastify.inject({
+            method: 'DELETE',
+            url: `/v1/${eventId}/sponsors/jobPosts/${jobPostId}?apiKey=${apiKey}`,
+        })
+
+        expect(res.statusCode).toBe(404)
+        expect(res.body).toContain('Job post not found')
+    })
+
+    test('returns 200 on happy path', async () => {
+        vi.spyOn(fastify.firebase, 'firestore').mockImplementation(() => {
+            return getMockedFirestore({ id: eventId, apiKey } as Partial<Event>)
+        })
+        vi.spyOn(JobPostDao, 'getJobPost').mockResolvedValue({ id: jobPostId } as any)
+        const deleteSpy = vi.spyOn(JobPostDao, 'deleteJobPost').mockResolvedValue(true)
+
+        const res = await fastify.inject({
+            method: 'DELETE',
+            url: `/v1/${eventId}/sponsors/jobPosts/${jobPostId}?apiKey=${apiKey}`,
+        })
+
+        expect(res.statusCode).toBe(200)
+        expect(JSON.parse(res.body)).toMatchObject({ success: true })
+        expect(deleteSpy).toHaveBeenCalledWith(fastify.firebase, eventId, jobPostId)
+    })
+})
+
+describe('DELETE /v1/:eventId/sponsors/job-posts/:jobPostId (sponsor token)', () => {
+    afterEach(() => {
+        vi.restoreAllMocks()
+    })
+
+    test('returns 400 when sponsorToken query param is missing', async () => {
+        const res = await fastify.inject({
+            method: 'DELETE',
+            url: `/v1/${eventId}/sponsors/job-posts/${jobPostId}`,
+        })
+        expect(res.statusCode).toBe(400)
+        expect(JSON.parse(res.body)).toMatchObject({ error: 'FST_ERR_VALIDATION' })
+    })
+
+    test('returns 401 when sponsor token is invalid', async () => {
+        vi.spyOn(SponsorDao, 'findSponsorByToken').mockResolvedValue(null)
+
+        const res = await fastify.inject({
+            method: 'DELETE',
+            url: `/v1/${eventId}/sponsors/job-posts/${jobPostId}?sponsorToken=bad`,
+        })
+
+        expect(res.statusCode).toBe(401)
+        expect(res.body).toContain('Invalid sponsor token')
+    })
+
+    test('returns 401 when sponsor is not owner', async () => {
+        vi.spyOn(SponsorDao, 'findSponsorByToken').mockResolvedValue({
+            sponsor: { id: 'spk-1' } as any,
+            categoryId: 'cat-1',
+        })
+        vi.spyOn(JobPostDao, 'getJobPost').mockResolvedValue({
+            id: jobPostId,
+            sponsorId: 'spk-other',
+        } as any)
+
+        const res = await fastify.inject({
+            method: 'DELETE',
+            url: `/v1/${eventId}/sponsors/job-posts/${jobPostId}?sponsorToken=good`,
+        })
+
+        expect(res.statusCode).toBe(401)
+        expect(res.body).toContain('Not authorized')
+    })
+
+    test('returns 200 on happy path', async () => {
+        vi.spyOn(SponsorDao, 'findSponsorByToken').mockResolvedValue({
+            sponsor: { id: 'spk-1' } as any,
+            categoryId: 'cat-1',
+        })
+        vi.spyOn(JobPostDao, 'getJobPost').mockResolvedValue({
+            id: jobPostId,
+            sponsorId: 'spk-1',
+        } as any)
+        const deleteSpy = vi.spyOn(JobPostDao, 'deleteJobPost').mockResolvedValue(true)
+
+        const res = await fastify.inject({
+            method: 'DELETE',
+            url: `/v1/${eventId}/sponsors/job-posts/${jobPostId}?sponsorToken=good`,
+        })
+
+        expect(res.statusCode).toBe(200)
+        expect(JSON.parse(res.body)).toMatchObject({ success: true })
+        expect(deleteSpy).toHaveBeenCalledWith(fastify.firebase, eventId, jobPostId)
+    })
+})

--- a/functions/src/api/routes/sponsors/generateSponsorTokenPOST.test.ts
+++ b/functions/src/api/routes/sponsors/generateSponsorTokenPOST.test.ts
@@ -1,0 +1,69 @@
+import { afterEach, describe, expect, test, vi } from 'vitest'
+import { setupFastify } from '../../setupFastify'
+import { getMockedFirestore } from '../../testUtils/mockedFirestore'
+import { Event } from '../../../types'
+import { SponsorDao } from '../../dao/sponsorDao'
+
+vi.mock('../../dao/firebasePlugin', async (importOriginal) => {
+    const mod = await importOriginal<typeof import('../../dao/firebasePlugin')>()
+    return {
+        ...mod,
+        setupFirebase: vi.fn().mockImplementation((fastify, _options, next) => {
+            next()
+        }),
+    }
+})
+
+describe('POST /v1/:eventId/sponsors/generate-token', () => {
+    const eventId = 'evt-1'
+    const apiKey = 'xxx'
+    const fastify = setupFastify()
+
+    afterEach(() => {
+        vi.restoreAllMocks()
+    })
+
+    test('returns 401 if apiKey is missing', async () => {
+        const res = await fastify.inject({
+            method: 'POST',
+            url: `/v1/${eventId}/sponsors/generate-token`,
+            payload: { sponsorId: 'spk-1', categoryId: 'cat-1' },
+        })
+        expect(res.statusCode).toBe(401)
+        expect(JSON.parse(res.body)).toMatchObject({ error: 'Unauthorized! Du balai !' })
+    })
+
+    test('returns 404 if sponsor lookup fails', async () => {
+        vi.spyOn(fastify.firebase, 'firestore').mockImplementation(() => {
+            return getMockedFirestore({ id: eventId, apiKey } as Partial<Event>)
+        })
+        vi.spyOn(SponsorDao, 'getSponsor').mockRejectedValue(new Error('Sponsor not found'))
+
+        const res = await fastify.inject({
+            method: 'POST',
+            url: `/v1/${eventId}/sponsors/generate-token?apiKey=${apiKey}`,
+            payload: { sponsorId: 'spk-1', categoryId: 'cat-1' },
+        })
+
+        expect(res.statusCode).toBe(404)
+        expect(res.body).toContain('Sponsor not found')
+    })
+
+    test('returns 201 with the generated token on happy path', async () => {
+        vi.spyOn(fastify.firebase, 'firestore').mockImplementation(() => {
+            return getMockedFirestore({ id: eventId, apiKey } as Partial<Event>)
+        })
+        vi.spyOn(SponsorDao, 'getSponsor').mockResolvedValue({ id: 'spk-1' } as any)
+        const tokenSpy = vi.spyOn(SponsorDao, 'generateTokenForSponsor').mockResolvedValue('token-abc')
+
+        const res = await fastify.inject({
+            method: 'POST',
+            url: `/v1/${eventId}/sponsors/generate-token?apiKey=${apiKey}`,
+            payload: { sponsorId: 'spk-1', categoryId: 'cat-1' },
+        })
+
+        expect(res.statusCode).toBe(201)
+        expect(JSON.parse(res.body)).toMatchObject({ token: 'token-abc' })
+        expect(tokenSpy).toHaveBeenCalledWith(fastify.firebase, eventId, 'cat-1', 'spk-1')
+    })
+})

--- a/functions/src/api/routes/sponsors/getJobPostGET.test.ts
+++ b/functions/src/api/routes/sponsors/getJobPostGET.test.ts
@@ -1,0 +1,76 @@
+import { afterEach, describe, expect, test, vi } from 'vitest'
+import { setupFastify } from '../../setupFastify'
+import { getMockedFirestore } from '../../testUtils/mockedFirestore'
+import { Event } from '../../../types'
+import { JobPostDao } from '../../dao/jobPostDao'
+import { JobStatus } from '../../../../../src/constants/jobStatus'
+
+vi.mock('../../dao/firebasePlugin', async (importOriginal) => {
+    const mod = await importOriginal<typeof import('../../dao/firebasePlugin')>()
+    return {
+        ...mod,
+        setupFirebase: vi.fn().mockImplementation((fastify, _options, next) => {
+            next()
+        }),
+    }
+})
+
+describe('GET /v1/:eventId/sponsors/jobPosts/:jobPostId', () => {
+    const eventId = 'evt-1'
+    const jobPostId = 'jp-1'
+    const apiKey = 'xxx'
+    const fastify = setupFastify()
+
+    afterEach(() => {
+        vi.restoreAllMocks()
+    })
+
+    test('returns 401 if apiKey is missing', async () => {
+        const res = await fastify.inject({
+            method: 'GET',
+            url: `/v1/${eventId}/sponsors/jobPosts/${jobPostId}`,
+        })
+        expect(res.statusCode).toBe(401)
+        expect(JSON.parse(res.body)).toMatchObject({ error: 'Unauthorized! Du balai !' })
+    })
+
+    test('returns 404 when getJobPost throws', async () => {
+        vi.spyOn(fastify.firebase, 'firestore').mockImplementation(() => {
+            return getMockedFirestore({ id: eventId, apiKey } as Partial<Event>)
+        })
+        vi.spyOn(JobPostDao, 'getJobPost').mockRejectedValue(new Error('Job post not found'))
+
+        const res = await fastify.inject({
+            method: 'GET',
+            url: `/v1/${eventId}/sponsors/jobPosts/${jobPostId}?apiKey=${apiKey}`,
+        })
+
+        expect(res.statusCode).toBe(404)
+        expect(res.body).toContain('Job post not found')
+    })
+
+    test('returns 200 with job post on happy path', async () => {
+        vi.spyOn(fastify.firebase, 'firestore').mockImplementation(() => {
+            return getMockedFirestore({ id: eventId, apiKey } as Partial<Event>)
+        })
+        vi.spyOn(JobPostDao, 'getJobPost').mockResolvedValue({
+            id: jobPostId,
+            sponsorId: 'spk-1',
+            title: 'Job',
+            description: 'desc',
+            location: 'loc',
+            externalLink: 'https://x.test',
+            category: 'Software Developer',
+            status: JobStatus.PENDING,
+            createdAt: {} as any,
+        } as any)
+
+        const res = await fastify.inject({
+            method: 'GET',
+            url: `/v1/${eventId}/sponsors/jobPosts/${jobPostId}?apiKey=${apiKey}`,
+        })
+
+        expect(res.statusCode).toBe(200)
+        expect(JSON.parse(res.body)).toMatchObject({ id: jobPostId, title: 'Job' })
+    })
+})

--- a/functions/src/api/routes/sponsors/getJobPostsGET.test.ts
+++ b/functions/src/api/routes/sponsors/getJobPostsGET.test.ts
@@ -1,0 +1,84 @@
+import { afterEach, describe, expect, test, vi } from 'vitest'
+import { setupFastify } from '../../setupFastify'
+import { getMockedFirestore } from '../../testUtils/mockedFirestore'
+import { Event } from '../../../types'
+import { JobPostDao } from '../../dao/jobPostDao'
+import { JobStatus } from '../../../../../src/constants/jobStatus'
+
+const sampleJobPost = {
+    id: 'jp-1',
+    sponsorId: 'spk-1',
+    title: 'A',
+    description: 'd',
+    location: 'l',
+    externalLink: 'https://x.test',
+    status: JobStatus.PENDING,
+    createdAt: {} as any,
+} as any
+
+vi.mock('../../dao/firebasePlugin', async (importOriginal) => {
+    const mod = await importOriginal<typeof import('../../dao/firebasePlugin')>()
+    return {
+        ...mod,
+        setupFirebase: vi.fn().mockImplementation((fastify, _options, next) => {
+            next()
+        }),
+    }
+})
+
+describe('GET /v1/:eventId/sponsors/jobPosts', () => {
+    const eventId = 'evt-1'
+    const apiKey = 'xxx'
+    const fastify = setupFastify()
+
+    afterEach(() => {
+        vi.restoreAllMocks()
+    })
+
+    test('returns 401 if apiKey is missing', async () => {
+        const res = await fastify.inject({
+            method: 'GET',
+            url: `/v1/${eventId}/sponsors/jobPosts`,
+        })
+        expect(res.statusCode).toBe(401)
+        expect(JSON.parse(res.body)).toMatchObject({ error: 'Unauthorized! Du balai !' })
+    })
+
+    test('returns 200 with all job posts when no sponsorId', async () => {
+        vi.spyOn(fastify.firebase, 'firestore').mockImplementation(() => {
+            return getMockedFirestore({ id: eventId, apiKey } as Partial<Event>)
+        })
+        const allSpy = vi.spyOn(JobPostDao, 'getAllJobPosts').mockResolvedValue([sampleJobPost])
+        const bySponsorSpy = vi.spyOn(JobPostDao, 'getJobPostsBySponsor')
+
+        const res = await fastify.inject({
+            method: 'GET',
+            url: `/v1/${eventId}/sponsors/jobPosts?apiKey=${apiKey}`,
+        })
+
+        expect(res.statusCode).toBe(200)
+        expect(JSON.parse(res.body)).toMatchObject([{ id: 'jp-1', sponsorId: 'spk-1' }])
+        expect(allSpy).toHaveBeenCalledTimes(1)
+        expect(bySponsorSpy).not.toHaveBeenCalled()
+    })
+
+    test('returns 200 with job posts filtered by sponsorId', async () => {
+        vi.spyOn(fastify.firebase, 'firestore').mockImplementation(() => {
+            return getMockedFirestore({ id: eventId, apiKey } as Partial<Event>)
+        })
+        const bySponsorSpy = vi
+            .spyOn(JobPostDao, 'getJobPostsBySponsor')
+            .mockResolvedValue([{ ...sampleJobPost, id: 'jp-2', sponsorId: 'spk-1' }])
+        const allSpy = vi.spyOn(JobPostDao, 'getAllJobPosts')
+
+        const res = await fastify.inject({
+            method: 'GET',
+            url: `/v1/${eventId}/sponsors/jobPosts?apiKey=${apiKey}&sponsorId=spk-1`,
+        })
+
+        expect(res.statusCode).toBe(200)
+        expect(JSON.parse(res.body)).toMatchObject([{ id: 'jp-2', sponsorId: 'spk-1' }])
+        expect(bySponsorSpy).toHaveBeenCalledWith(fastify.firebase, eventId, 'spk-1', undefined)
+        expect(allSpy).not.toHaveBeenCalled()
+    })
+})

--- a/functions/src/api/routes/sponsors/getSponsorJobPostsGET.test.ts
+++ b/functions/src/api/routes/sponsors/getSponsorJobPostsGET.test.ts
@@ -1,0 +1,81 @@
+import { afterEach, describe, expect, test, vi } from 'vitest'
+import { setupFastify } from '../../setupFastify'
+import { JobPostDao } from '../../dao/jobPostDao'
+import { SponsorDao } from '../../dao/sponsorDao'
+import { JobStatus } from '../../../../../src/constants/jobStatus'
+
+vi.mock('../../dao/firebasePlugin', async (importOriginal) => {
+    const mod = await importOriginal<typeof import('../../dao/firebasePlugin')>()
+    return {
+        ...mod,
+        setupFirebase: vi.fn().mockImplementation((fastify, _options, next) => {
+            next()
+        }),
+    }
+})
+
+describe('GET /v1/:eventId/sponsors/job-posts', () => {
+    const eventId = 'evt-1'
+    const fastify = setupFastify()
+
+    afterEach(() => {
+        vi.restoreAllMocks()
+    })
+
+    test('returns 400 when sponsorToken is missing', async () => {
+        const res = await fastify.inject({
+            method: 'GET',
+            url: `/v1/${eventId}/sponsors/job-posts`,
+        })
+        expect(res.statusCode).toBe(400)
+        expect(JSON.parse(res.body)).toMatchObject({ error: 'FST_ERR_VALIDATION' })
+    })
+
+    test('returns 401 when sponsor token is invalid', async () => {
+        vi.spyOn(SponsorDao, 'findSponsorByToken').mockResolvedValue(null)
+
+        const res = await fastify.inject({
+            method: 'GET',
+            url: `/v1/${eventId}/sponsors/job-posts?sponsorToken=bad`,
+        })
+
+        expect(res.statusCode).toBe(401)
+        expect(res.body).toContain('Invalid sponsor token')
+    })
+
+    test('returns 200 with sponsor and jobPosts on happy path', async () => {
+        vi.spyOn(SponsorDao, 'findSponsorByToken').mockResolvedValue({
+            sponsor: {
+                id: 'spk-1',
+                name: 'Acme',
+                logoUrl: 'https://logo.test',
+                website: 'https://acme.test',
+            } as any,
+            categoryId: 'cat-1',
+        })
+        vi.spyOn(JobPostDao, 'getJobPostsBySponsor').mockResolvedValue([
+            {
+                id: 'jp-1',
+                sponsorId: 'spk-1',
+                title: 'A',
+                description: 'd',
+                location: 'l',
+                externalLink: 'https://x.test',
+                category: 'Software Developer',
+                status: JobStatus.PENDING,
+                createdAt: {} as any,
+            } as any,
+        ])
+
+        const res = await fastify.inject({
+            method: 'GET',
+            url: `/v1/${eventId}/sponsors/job-posts?sponsorToken=good`,
+        })
+
+        expect(res.statusCode).toBe(200)
+        expect(JSON.parse(res.body)).toMatchObject({
+            sponsor: { id: 'spk-1', name: 'Acme' },
+            jobPosts: [{ id: 'jp-1', sponsorId: 'spk-1' }],
+        })
+    })
+})

--- a/functions/src/api/routes/sponsors/trackJobPostClickPOST.test.ts
+++ b/functions/src/api/routes/sponsors/trackJobPostClickPOST.test.ts
@@ -1,0 +1,73 @@
+import { afterEach, describe, expect, test, vi } from 'vitest'
+import { setupFastify } from '../../setupFastify'
+import { JobPostDao } from '../../dao/jobPostDao'
+
+vi.mock('../../dao/firebasePlugin', async (importOriginal) => {
+    const mod = await importOriginal<typeof import('../../dao/firebasePlugin')>()
+    return {
+        ...mod,
+        setupFirebase: vi.fn().mockImplementation((fastify, _options, next) => {
+            next()
+        }),
+    }
+})
+
+describe('POST /v1/:eventId/sponsors/jobPosts/track-click', () => {
+    const eventId = 'evt-1'
+    const fastify = setupFastify()
+
+    afterEach(() => {
+        vi.restoreAllMocks()
+    })
+
+    test('returns 400 when body field jobPostId is missing', async () => {
+        const res = await fastify.inject({
+            method: 'POST',
+            url: `/v1/${eventId}/sponsors/jobPosts/track-click`,
+            payload: {},
+        })
+        expect(res.statusCode).toBe(400)
+        expect(JSON.parse(res.body)).toMatchObject({ error: 'FST_ERR_VALIDATION' })
+    })
+
+    test('returns 404 when getJobPost throws', async () => {
+        vi.spyOn(JobPostDao, 'getJobPost').mockRejectedValue(new Error('Job post not found'))
+
+        const res = await fastify.inject({
+            method: 'POST',
+            url: `/v1/${eventId}/sponsors/jobPosts/track-click`,
+            payload: { jobPostId: 'jp-1' },
+        })
+
+        expect(res.statusCode).toBe(404)
+        expect(res.body).toContain('Job post not found')
+    })
+
+    test('returns 200 on happy path when trackJobPostClick returns true', async () => {
+        vi.spyOn(JobPostDao, 'getJobPost').mockResolvedValue({ id: 'jp-1' } as any)
+        vi.spyOn(JobPostDao, 'trackJobPostClick').mockResolvedValue(true)
+
+        const res = await fastify.inject({
+            method: 'POST',
+            url: `/v1/${eventId}/sponsors/jobPosts/track-click`,
+            payload: { jobPostId: 'jp-1' },
+        })
+
+        expect(res.statusCode).toBe(200)
+        expect(JSON.parse(res.body)).toMatchObject({ success: true })
+    })
+
+    test('returns 400 when trackJobPostClick returns false', async () => {
+        vi.spyOn(JobPostDao, 'getJobPost').mockResolvedValue({ id: 'jp-1' } as any)
+        vi.spyOn(JobPostDao, 'trackJobPostClick').mockResolvedValue(false)
+
+        const res = await fastify.inject({
+            method: 'POST',
+            url: `/v1/${eventId}/sponsors/jobPosts/track-click`,
+            payload: { jobPostId: 'jp-1' },
+        })
+
+        expect(res.statusCode).toBe(400)
+        expect(res.body).toContain('Failed to track job post click')
+    })
+})

--- a/functions/src/api/routes/sponsors/updateJobPostPUT.test.ts
+++ b/functions/src/api/routes/sponsors/updateJobPostPUT.test.ts
@@ -1,0 +1,108 @@
+import { afterEach, describe, expect, test, vi } from 'vitest'
+import { setupFastify } from '../../setupFastify'
+import { JobPostDao } from '../../dao/jobPostDao'
+import { SponsorDao } from '../../dao/sponsorDao'
+
+vi.mock('../../dao/firebasePlugin', async (importOriginal) => {
+    const mod = await importOriginal<typeof import('../../dao/firebasePlugin')>()
+    return {
+        ...mod,
+        setupFirebase: vi.fn().mockImplementation((fastify, _options, next) => {
+            next()
+        }),
+    }
+})
+
+describe('PUT /v1/:eventId/sponsors/job-posts/:jobPostId', () => {
+    const eventId = 'evt-1'
+    const jobPostId = 'jp-1'
+    const fastify = setupFastify()
+
+    const validBody = {
+        title: 'Updated Title',
+        description: 'desc',
+        location: 'loc',
+        externalLink: 'https://x.test',
+        category: 'Software Developer',
+        sponsorToken: 'token',
+    }
+
+    afterEach(() => {
+        vi.restoreAllMocks()
+    })
+
+    test('returns 401 when sponsor token is invalid', async () => {
+        vi.spyOn(SponsorDao, 'findSponsorByToken').mockResolvedValue(null)
+
+        const res = await fastify.inject({
+            method: 'PUT',
+            url: `/v1/${eventId}/sponsors/job-posts/${jobPostId}`,
+            payload: validBody,
+        })
+
+        expect(res.statusCode).toBe(401)
+        expect(res.body).toContain('Invalid sponsor token')
+    })
+
+    test('returns 401 when sponsor does not own the job post', async () => {
+        vi.spyOn(SponsorDao, 'findSponsorByToken').mockResolvedValue({
+            sponsor: { id: 'spk-1' } as any,
+            categoryId: 'cat-1',
+        })
+        vi.spyOn(JobPostDao, 'getJobPost').mockResolvedValue({
+            id: jobPostId,
+            sponsorId: 'spk-other',
+        } as any)
+
+        const res = await fastify.inject({
+            method: 'PUT',
+            url: `/v1/${eventId}/sponsors/job-posts/${jobPostId}`,
+            payload: validBody,
+        })
+
+        expect(res.statusCode).toBe(401)
+        expect(res.body).toContain('Not authorized')
+    })
+
+    test('returns 404 when job post is missing', async () => {
+        vi.spyOn(SponsorDao, 'findSponsorByToken').mockResolvedValue({
+            sponsor: { id: 'spk-1' } as any,
+            categoryId: 'cat-1',
+        })
+        vi.spyOn(JobPostDao, 'getJobPost').mockRejectedValue(new Error('Job post not found'))
+
+        const res = await fastify.inject({
+            method: 'PUT',
+            url: `/v1/${eventId}/sponsors/job-posts/${jobPostId}`,
+            payload: validBody,
+        })
+
+        expect(res.statusCode).toBe(404)
+        expect(res.body).toContain('Job post not found')
+    })
+
+    test('returns 200 on happy path', async () => {
+        vi.spyOn(SponsorDao, 'findSponsorByToken').mockResolvedValue({
+            sponsor: { id: 'spk-1' } as any,
+            categoryId: 'cat-1',
+        })
+        vi.spyOn(JobPostDao, 'getJobPost').mockResolvedValue({
+            id: jobPostId,
+            sponsorId: 'spk-1',
+        } as any)
+        const updateSpy = vi.spyOn(JobPostDao, 'updateJobPost').mockResolvedValue(true)
+
+        const res = await fastify.inject({
+            method: 'PUT',
+            url: `/v1/${eventId}/sponsors/job-posts/${jobPostId}`,
+            payload: validBody,
+        })
+
+        expect(res.statusCode).toBe(200)
+        expect(JSON.parse(res.body)).toMatchObject({ success: true })
+        expect(updateSpy).toHaveBeenCalledTimes(1)
+        const updateData = updateSpy.mock.calls[0][3]
+        expect((updateData as any).sponsorToken).toBeUndefined()
+        expect(updateData).toMatchObject({ title: 'Updated Title' })
+    })
+})

--- a/functions/src/api/routes/transcription/transcription.test.ts
+++ b/functions/src/api/routes/transcription/transcription.test.ts
@@ -1,0 +1,98 @@
+import { afterEach, describe, expect, test, vi } from 'vitest'
+import { setupFastify } from '../../setupFastify'
+import { EventDao } from '../../dao/eventDao'
+import { Event } from '../../../types'
+
+vi.mock('../../dao/firebasePlugin', async (importOriginal) => {
+    const mod = await importOriginal<typeof import('../../dao/firebasePlugin')>()
+    return {
+        ...mod,
+        setupFirebase: vi.fn().mockImplementation((_fastify, _options, next) => next()),
+        getStorageBucketName: () => 'test-bucket',
+    }
+})
+
+const eventId = 'evt-1'
+
+describe('GET /v1/:eventId/transcription', () => {
+    const fastify = setupFastify()
+
+    afterEach(() => {
+        vi.restoreAllMocks()
+    })
+
+    test('returns 401 if gladia api key or password is missing', async () => {
+        vi.spyOn(EventDao, 'getEvent').mockResolvedValue({
+            id: eventId,
+            name: 'Test',
+            gladiaAPIKey: null,
+            transcriptionPassword: null,
+        } as unknown as Event)
+
+        const res = await fastify.inject({
+            method: 'get',
+            url: `/v1/${eventId}/transcription`,
+            headers: { password: 'whatever' },
+        })
+        expect(res.statusCode).toBe(401)
+        expect(res.body).toContain('Missing Gladia API Key or password')
+    })
+
+    test('returns 401 if password header does not match', async () => {
+        vi.spyOn(EventDao, 'getEvent').mockResolvedValue({
+            id: eventId,
+            name: 'Test',
+            gladiaAPIKey: 'gk',
+            transcriptionPassword: 'expected',
+            files: { public: 'public.json' },
+        } as unknown as Event)
+
+        const res = await fastify.inject({
+            method: 'get',
+            url: `/v1/${eventId}/transcription`,
+            headers: { password: 'wrong' },
+        })
+        expect(res.statusCode).toBe(401)
+        expect(res.body).toContain('Passwords does not match')
+    })
+
+    test('returns 401 if files.public is missing', async () => {
+        vi.spyOn(EventDao, 'getEvent').mockResolvedValue({
+            id: eventId,
+            name: 'Test',
+            gladiaAPIKey: 'gk',
+            transcriptionPassword: 'p',
+            files: null,
+        } as unknown as Event)
+
+        const res = await fastify.inject({
+            method: 'get',
+            url: `/v1/${eventId}/transcription`,
+            headers: { password: 'p' },
+        })
+        expect(res.statusCode).toBe(401)
+        expect(res.body).toContain('Missing public file')
+    })
+
+    test('returns 200 with the gladia api key when password matches', async () => {
+        vi.spyOn(EventDao, 'getEvent').mockResolvedValue({
+            id: eventId,
+            name: 'Test Event',
+            gladiaAPIKey: 'secret-gladia',
+            transcriptionPassword: 'p',
+            files: { public: 'public.json' },
+        } as unknown as Event)
+
+        const res = await fastify.inject({
+            method: 'get',
+            url: `/v1/${eventId}/transcription`,
+            headers: { password: 'p' },
+        })
+        expect(res.statusCode).toBe(200)
+        expect(JSON.parse(res.body)).toMatchObject({
+            eventName: 'Test Event',
+            gladiaAPIKey: 'secret-gladia',
+            dataUrl: 'https://storage.googleapis.com/test-bucket/public.json',
+        })
+    })
+})

--- a/functions/src/api/routes/transcription/transcription.test.ts
+++ b/functions/src/api/routes/transcription/transcription.test.ts
@@ -53,7 +53,9 @@ describe('GET /v1/:eventId/transcription', () => {
             headers: { password: 'wrong' },
         })
         expect(res.statusCode).toBe(401)
-        expect(res.body).toContain('Passwords does not match')
+        expect(JSON.parse(res.body)).toMatchObject({
+            error: 'Password does not match',
+        })
     })
 
     test('returns 401 if files.public is missing', async () => {

--- a/functions/src/api/routes/transcription/transcription.ts
+++ b/functions/src/api/routes/transcription/transcription.ts
@@ -52,7 +52,7 @@ export const transcriptionRoutes = (fastify: FastifyInstance, options: any, done
             if (event.transcriptionPassword !== password) {
                 reply.status(401).send(
                     JSON.stringify({
-                        error: 'Passwords does not match',
+                        error: 'Password does not match',
                     })
                 )
                 return


### PR DESCRIPTION
## Summary

Cover the HTTP routes in \`functions/src/api/routes/\` (everything except the \`pdf/\` folder) with vitest unit tests, following the existing mocked-Firestore pattern (top-of-file \`vi.mock('../../dao/firebasePlugin')\` + per-test \`getMockedFirestore\` for the apiKey lookup, \`vi.spyOn\` on DAOs for route logic).

### Routes covered

- \`speakers/updateSpeakerPATCH\` — auth, validation, partial update, customFields deep-merge, social icon derivation, firestore-error path.
- \`hello/hello\`
- \`event/getEvent\`
- \`transcription/transcription\`
- \`faq/faq\` (POST + GET)
- \`sessions/sessions\` (\`/shortvid\` — auth + body validation)
- \`file/addFilePOST\`, \`file/downloadAndReuploadFilePOST\` (auth + body validation; multipart not exercised)
- \`deploy/deploy\`, \`deploy/getDeployFiles\` (auth + happy path with module-mocked deploy actions)
- \`bupher/login\`, \`bupher/channels\`, \`bupher/scheduled-posts\`, \`bupher/draft-post\` (auth + body validation; the external Bupher API is not exercised)
- \`sponsors/addSponsor\`, \`sponsors/generateSponsorToken\`, \`sponsors/addJobPost\` (private id + sponsor token), \`sponsors/getJobPosts\`, \`sponsors/getJobPost\`, \`sponsors/approveJobPost\`, \`sponsors/updateJobPost\`, \`sponsors/deleteJobPost\` (apiKey + sponsor token), \`sponsors/getSponsorJobPosts\`, \`sponsors/trackJobPostClick\`.

Skipped: anything in \`pdf/\`, \`event/exportSchedulePdf\`, \`event/getPdfMetadata\` (PDF-related, per request).

### Bug fix from review

- \`transcription.ts\`: 401 reply message changed from \"Passwords does not match\" to \"Password does not match\".

## Stats

- 24 new test files, ~80 new tests.
- Full functions suite: **98 tests, all passing** (\`cd functions && npm test\`).

## Test plan

- [ ] \`cd functions && npm test\` — 98/98 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)