### PR TITLE
Fix blank page after deploy when navigating in a stale tab

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { lazy, Suspense } from 'react'
+import { Suspense } from 'react'
 import { Box, createTheme, CssBaseline, Typography, ThemeProvider, useMediaQuery } from '@mui/material'
 import { Link, Redirect, Route, Router, Switch } from 'wouter'
 import { RequireLogin } from './auth/RequireLogin'
@@ -14,8 +14,9 @@ import { PublicApp } from './public/PublicApp'
 import { ForgotPasswordScreen } from './auth/ForgotPasswordScreen'
 import { AdminScreen } from './events/admin/AdminScreen'
 import { EventApp } from './events/page/EventApp'
+import { lazyWithRetry } from './components/lazyWithRetry'
 
-const EventsScreen = lazy(() =>
+const EventsScreen = lazyWithRetry(() =>
     import('./events/list/EventsScreen').then((module) => ({ default: module.EventsScreen }))
 )
 

--- a/src/components/lazyWithRetry.ts
+++ b/src/components/lazyWithRetry.ts
@@ -21,16 +21,41 @@ const isChunkLoadError = (error: unknown): boolean => {
     )
 }
 
+const clearReloadFlag = (): void => {
+    try {
+        window.sessionStorage.removeItem(RELOAD_FLAG)
+    } catch {
+        // Ignore storage access failures so successful imports still resolve.
+    }
+}
+
+const hasAlreadyRetried = (): boolean => {
+    try {
+        return window.sessionStorage.getItem(RELOAD_FLAG) === '1'
+    } catch {
+        // If storage is unavailable, avoid a reload attempt and surface the original error.
+        return true
+    }
+}
+
+const markReloadAttempted = (): void => {
+    try {
+        window.sessionStorage.setItem(RELOAD_FLAG, '1')
+    } catch {
+        // Ignore storage access failures; caller will continue with a safe fallback path.
+    }
+}
+
 export const lazyWithRetry = <T extends ComponentType<any>>(factory: () => Promise<{ default: T }>) =>
     lazy(async () => {
         try {
             const mod = await factory()
-            window.sessionStorage.removeItem(RELOAD_FLAG)
+            clearReloadFlag()
             return mod
         } catch (error) {
-            const alreadyTried = window.sessionStorage.getItem(RELOAD_FLAG) === '1'
+            const alreadyTried = hasAlreadyRetried()
             if (isChunkLoadError(error) && !alreadyTried) {
-                window.sessionStorage.setItem(RELOAD_FLAG, '1')
+                markReloadAttempted()
                 window.location.reload()
                 return new Promise<{ default: T }>(() => {})
             }

--- a/src/components/lazyWithRetry.ts
+++ b/src/components/lazyWithRetry.ts
@@ -1,0 +1,39 @@
+import { ComponentType, lazy } from 'react'
+
+// After a deploy, the hashed chunk URL referenced by an open tab no longer
+// exists on the host. Firebase Hosting then serves index.html for the missing
+// JS file (because of the `**` SPA rewrite), which fails to parse as a module
+// and rejects the dynamic import — unmounting the tree and showing a blank
+// page. We catch that rejection once, hard-reload to pick up the fresh
+// index.html (and therefore the fresh chunk URLs), and use a sessionStorage
+// flag to avoid looping forever if the failure is genuine.
+const RELOAD_FLAG = 'openplanner.chunkReloadAttempted'
+
+const isChunkLoadError = (error: unknown): boolean => {
+    if (!(error instanceof Error)) return false
+    const message = `${error.name} ${error.message}`
+    return (
+        /ChunkLoadError/i.test(message) ||
+        /Loading chunk \S+ failed/i.test(message) ||
+        /Failed to fetch dynamically imported module/i.test(message) ||
+        /error loading dynamically imported module/i.test(message) ||
+        /Importing a module script failed/i.test(message)
+    )
+}
+
+export const lazyWithRetry = <T extends ComponentType<any>>(factory: () => Promise<{ default: T }>) =>
+    lazy(async () => {
+        try {
+            const mod = await factory()
+            window.sessionStorage.removeItem(RELOAD_FLAG)
+            return mod
+        } catch (error) {
+            const alreadyTried = window.sessionStorage.getItem(RELOAD_FLAG) === '1'
+            if (isChunkLoadError(error) && !alreadyTried) {
+                window.sessionStorage.setItem(RELOAD_FLAG, '1')
+                window.location.reload()
+                return new Promise<{ default: T }>(() => {})
+            }
+            throw error
+        }
+    })

--- a/src/events/page/EventApp.tsx
+++ b/src/events/page/EventApp.tsx
@@ -1,10 +1,11 @@
-import { lazy, Suspense, useEffect } from 'react'
+import { Suspense, useEffect } from 'react'
 import { Redirect, Route, Switch } from 'wouter'
 import { EventLayout } from './layouts/EventLayout'
 import { useEvent } from '../../services/hooks/useEvent'
 import { FirestoreQueryLoaderAndErrorDisplay } from '../../components/FirestoreQueryLoaderAndErrorDisplay'
 import { Event } from '../../types'
 import { SuspenseLoader } from '../../components/SuspenseLoader'
+import { lazyWithRetry } from '../../components/lazyWithRetry'
 
 import { NewMember } from './team/NewMember'
 import { NewSponsor } from './sponsors/NewSponsor'
@@ -14,34 +15,44 @@ import { EventSpeaker } from './speakers/EventSpeaker'
 import { EventSocial } from './social/EventSocial'
 import { NewTicket } from './tickets/NewTicket'
 
-const EventSettings = lazy(() =>
+const EventSettings = lazyWithRetry(() =>
     import('./settings/EventSettings').then((module) => ({ default: module.EventSettings }))
 )
-const EventAPI = lazy(() => import('./api/Api').then((module) => ({ default: module.API })))
-const EventSchedule = lazy(() =>
+const EventAPI = lazyWithRetry(() => import('./api/Api').then((module) => ({ default: module.API })))
+const EventSchedule = lazyWithRetry(() =>
     import('./schedule/EventSchedule').then((module) => ({ default: module.EventSchedule }))
 )
-const EventScheduleTemplate = lazy(() =>
+const EventScheduleTemplate = lazyWithRetry(() =>
     import('./schedule/EventScheduleTemplate').then((module) => ({ default: module.EventScheduleTemplate }))
 )
-const EventSessions = lazy(() =>
+const EventSessions = lazyWithRetry(() =>
     import('./sessions/list/EventSessions').then((module) => ({ default: module.EventSessions }))
 )
-const EventSession = lazy(() => import('./sessions/EventSession').then((module) => ({ default: module.EventSession })))
-const EventSpeakers = lazy(() =>
+const EventSession = lazyWithRetry(() =>
+    import('./sessions/EventSession').then((module) => ({ default: module.EventSession }))
+)
+const EventSpeakers = lazyWithRetry(() =>
     import('./speakers/EventSpeakers').then((module) => ({ default: module.EventSpeakers }))
 )
-const EventSponsors = lazy(() =>
+const EventSponsors = lazyWithRetry(() =>
     import('./sponsors/EventSponsors').then((module) => ({ default: module.EventSponsors }))
 )
-const Sponsor = lazy(() => import('./sponsors/Sponsor').then((module) => ({ default: module.Sponsor })))
-const JobPosts = lazy(() => import('./sponsors/jobposts/JobPosts').then((module) => ({ default: module.JobPosts })))
+const Sponsor = lazyWithRetry(() => import('./sponsors/Sponsor').then((module) => ({ default: module.Sponsor })))
+const JobPosts = lazyWithRetry(() =>
+    import('./sponsors/jobposts/JobPosts').then((module) => ({ default: module.JobPosts }))
+)
 
-const EventTeam = lazy(() => import('./team/EventTeam').then((module) => ({ default: module.EventTeam })))
-const EventMember = lazy(() => import('./team/EventMember').then((module) => ({ default: module.EventMember })))
-const EventFaq = lazy(() => import('./faq/EventFaq').then((module) => ({ default: module.EventFAQ })))
-const EventTickets = lazy(() => import('./tickets/EventTickets').then((module) => ({ default: module.EventTickets })))
-const EventTicket = lazy(() => import('./tickets/EventTicket').then((module) => ({ default: module.EventTicket })))
+const EventTeam = lazyWithRetry(() => import('./team/EventTeam').then((module) => ({ default: module.EventTeam })))
+const EventMember = lazyWithRetry(() =>
+    import('./team/EventMember').then((module) => ({ default: module.EventMember }))
+)
+const EventFaq = lazyWithRetry(() => import('./faq/EventFaq').then((module) => ({ default: module.EventFAQ })))
+const EventTickets = lazyWithRetry(() =>
+    import('./tickets/EventTickets').then((module) => ({ default: module.EventTickets }))
+)
+const EventTicket = lazyWithRetry(() =>
+    import('./tickets/EventTicket').then((module) => ({ default: module.EventTicket }))
+)
 
 export const EventApp = ({ eventId }: { eventId?: string }) => {
     const event = useEvent(eventId)


### PR DESCRIPTION
## Summary

After every deploy, navigating to a new route in an already-open tab can leave the user staring at a blank page. The cause is the standard "stale chunk" pattern:

- `App.tsx` and `EventApp.tsx` use `React.lazy(() => import(...))` for ~17 routes, so Vite emits per-route content-hashed JS chunks (e.g. `assets/EventSpeakers-abc123.js`).
- Each Firebase deploy uploads a fresh `dist/` with new content hashes; the previous chunk filenames are gone from the host.
- `firebase.json` rewrites `**` to `/index.html`, so when an open tab on the old build requests its old chunk URL, Hosting returns `index.html`. The browser tries to parse HTML as a module → the dynamic import rejects.
- There is no `ErrorBoundary` anywhere in the tree (verified by grep), so the rejection unmounts the app → white screen.

This PR adds a small `lazyWithRetry` helper that wraps `React.lazy`. On a chunk-load failure it triggers a single `window.location.reload()`, guarded by a `sessionStorage` flag so a *genuinely* failing import (network down, asset removed for real) surfaces normally instead of reload-looping. Successful loads clear the flag, so a second deploy in the same tab session can recover the same way.

`lazy(...)` is then replaced with `lazyWithRetry(...)` at the route boundaries in `src/App.tsx` (1 site) and `src/events/page/EventApp.tsx` (16 sites).

## Test plan

- [ ] Build locally (`bun run build`), serve `dist/`, open the app, then re-build with a code change so chunk hashes shift, swap `dist/`, and navigate to a different route in the still-open tab — page should reload itself once and render the target route.
- [ ] Disable network mid-navigation and confirm the app does NOT loop reloads (the sessionStorage flag stops at one attempt and the original error surfaces).
- [ ] Sanity-check normal navigation across `/events`, `/sessions`, `/speakers`, `/sponsors`, `/team`, `/faq`, `/schedule`, `/settings`, `/api`, `/tickets` — no extra reloads on the happy path.

https://claude.ai/code/session_01UDvv7pcPvqQ65YgdiAkYqQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01UDvv7pcPvqQ65YgdiAkYqQ)_