### PR TITLE
Preview session teasing without saving the prompt first

### DIFF
--- a/src/events/actions/sessions/generation/generateSessionTeasingTexts.ts
+++ b/src/events/actions/sessions/generation/generateSessionTeasingTexts.ts
@@ -30,6 +30,10 @@ export const generateSessionTeasingTexts = async (
 ): Promise<GeneratedSessionTeasingTextAnswer> => {
     const promptSystem = settings.aiSettings.sessions.teasingPromptSystem
     const promptUser = settings.aiSettings.sessions.teasingPromptUser
+    const generationSettings = {
+        model: settings.aiSettings.model,
+        temperature: settings.aiSettings.temperature,
+    }
 
     const filteredSessions = sessions.filter((session) => !session.teasingHidden)
     const sessionsCount = filteredSessions.length
@@ -51,7 +55,8 @@ export const generateSessionTeasingTexts = async (
                         TeasingPostSocials[socialKey],
                         session,
                         promptSystem,
-                        promptUser
+                        promptUser,
+                        generationSettings
                     )
             ).then((result) => ({
                 social: TeasingPostSocials[socialKey],

--- a/src/events/page/sessions/components/GenerateSessionsTextContentDialog.tsx
+++ b/src/events/page/sessions/components/GenerateSessionsTextContentDialog.tsx
@@ -1,4 +1,4 @@
-import { Event, Session } from '../../../../types'
+import { Event, EventAISettings, Session } from '../../../../types'
 import { Box, Button, CircularProgress, Dialog, DialogContent, Typography } from '@mui/material'
 import * as React from 'react'
 import {
@@ -30,8 +30,11 @@ export const GenerateSessionsTextContentDialog = ({
     forceGenerate?: boolean
 }) => {
     const { createNotification } = useNotification()
+    // Mirror the AI settings form so "Generate preview" runs against unsaved
+    // edits in the prompt/model/temperature inputs.
+    const [liveAiSettings, setLiveAiSettings] = React.useState<EventAISettings>(event.aiSettings || BaseAiSettings)
     const llmSettings: GenerateSessionTeasingTextsSettings = {
-        aiSettings: event.aiSettings || BaseAiSettings,
+        aiSettings: liveAiSettings,
         openRouterApiKey: event.openRouterAPIKey,
     }
 
@@ -85,7 +88,7 @@ export const GenerateSessionsTextContentDialog = ({
                     <br />
                 </Typography>
 
-                <SessionAISettings event={event} />
+                <SessionAISettings event={event} onValuesChange={setLiveAiSettings} />
 
                 {!event.openRouterAPIKey && (
                     <Typography>

--- a/src/events/page/sessions/components/GenerateSessionsTextContentDialog.tsx
+++ b/src/events/page/sessions/components/GenerateSessionsTextContentDialog.tsx
@@ -31,12 +31,14 @@ export const GenerateSessionsTextContentDialog = ({
 }) => {
     const { createNotification } = useNotification()
     // Mirror the AI settings form so "Generate preview" runs against unsaved
-    // edits in the prompt/model/temperature inputs.
-    const [liveAiSettings, setLiveAiSettings] = React.useState<EventAISettings>(event.aiSettings || BaseAiSettings)
-    const llmSettings: GenerateSessionTeasingTextsSettings = {
-        aiSettings: liveAiSettings,
+    // edits in the prompt/model/temperature inputs. Held in a ref so a
+    // keystroke doesn't re-render the whole dialog; we read it lazily when
+    // the user actually clicks a generate button.
+    const liveAiSettingsRef = React.useRef<EventAISettings>(event.aiSettings || BaseAiSettings)
+    const buildLlmSettings = (): GenerateSessionTeasingTextsSettings => ({
+        aiSettings: liveAiSettingsRef.current,
         openRouterApiKey: event.openRouterAPIKey,
-    }
+    })
 
     const { generatingState, generate } = useSessionsGenerationGeneric<
         GenerateSessionTeasingTextsSettings,
@@ -51,7 +53,7 @@ export const GenerateSessionsTextContentDialog = ({
 
     const generateAll = () => {
         const updateDoc = !onSuccess
-        finalGeneration.generate(sessionToGenerateFor, updateDoc, llmSettings).then(({ results, success }) => {
+        finalGeneration.generate(sessionToGenerateFor, updateDoc, buildLlmSettings()).then(({ results, success }) => {
             if (onSuccess && success && results.length) {
                 onSuccess(results[0].updatedSession.teasingPosts)
             }
@@ -88,7 +90,12 @@ export const GenerateSessionsTextContentDialog = ({
                     <br />
                 </Typography>
 
-                <SessionAISettings event={event} onValuesChange={setLiveAiSettings} />
+                <SessionAISettings
+                    event={event}
+                    onValuesChange={(values) => {
+                        liveAiSettingsRef.current = values
+                    }}
+                />
 
                 {!event.openRouterAPIKey && (
                     <Typography>
@@ -102,7 +109,7 @@ export const GenerateSessionsTextContentDialog = ({
                         variant="outlined"
                         disabled={generatingState.generationState === GenerationStates.GENERATING}
                         sx={{ marginRight: 2 }}
-                        onClick={() => generate(sessionToGenerateFor.slice(0, 1), false, llmSettings)}>
+                        onClick={() => generate(sessionToGenerateFor.slice(0, 1), false, buildLlmSettings())}>
                         {generatingState.generationState === 'GENERATING' ? (
                             <>
                                 Generating...

--- a/src/events/page/sessions/components/SessionAISettings.tsx
+++ b/src/events/page/sessions/components/SessionAISettings.tsx
@@ -7,7 +7,7 @@ import { useFirestoreDocumentMutation } from '../../../../services/hooks/firesto
 import { doc } from 'firebase/firestore'
 import { collections } from '../../../../services/firebase'
 import { Event, EventAISettings } from '../../../../types'
-import { GenerateSessionsTeasingContentPrompts } from '../../../actions/sessions/generation/generateSessionTeasingContent'
+import { GenerateSessionsTeasingContentPrompts, BaseAiSettings } from '../../../actions/sessions/generation/generateSessionTeasingContent'
 import { BASE_OPENROUTER_SETTINGS, useAiModelList } from '../../../../services/openRouter'
 
 export const SessionAISettings = ({
@@ -39,19 +39,26 @@ export const SessionAISettings = ({
     onValuesChangeRef.current = onValuesChange
     useEffect(() => {
         if (!onValuesChangeRef.current) return
+        // Empty/cleared inputs fall back to the persisted (or hard-coded
+        // default) settings so a half-edited form can't ship `temperature: ''`
+        // (which downstream parses to `NaN`) or an empty model id.
+        const fallback = event.aiSettings ?? BaseAiSettings
         const toSettings = (v: {
             teasingPromptSystem?: string
             teasingPromptUser?: string
             model?: string
             temperature?: string | number
-        }): EventAISettings => ({
-            model: v.model ?? '',
-            temperature: `${v.temperature ?? ''}`,
-            sessions: {
-                teasingPromptSystem: v.teasingPromptSystem ?? '',
-                teasingPromptUser: v.teasingPromptUser ?? '',
-            },
-        })
+        }): EventAISettings => {
+            const tempIsEmpty = v.temperature === undefined || v.temperature === null || v.temperature === ''
+            return {
+                model: v.model || fallback.model,
+                temperature: tempIsEmpty ? fallback.temperature : `${v.temperature}`,
+                sessions: {
+                    teasingPromptSystem: v.teasingPromptSystem || fallback.sessions.teasingPromptSystem,
+                    teasingPromptUser: v.teasingPromptUser || fallback.sessions.teasingPromptUser,
+                },
+            }
+        }
         // Seed parent with the current values, then keep it in sync.
         onValuesChangeRef.current(toSettings(formContext.getValues()))
         const subscription = formContext.watch((value) => {
@@ -59,7 +66,7 @@ export const SessionAISettings = ({
             onValuesChangeRef.current(toSettings(value))
         })
         return () => subscription.unsubscribe()
-    }, [formContext])
+    }, [formContext, event.aiSettings])
 
     return (
         <Box padding={2} borderRadius={2} border={1} borderColor="#66666688" mt={2} mb={2}>

--- a/src/events/page/sessions/components/SessionAISettings.tsx
+++ b/src/events/page/sessions/components/SessionAISettings.tsx
@@ -2,7 +2,7 @@ import { FormContainer, SelectElement, TextFieldElement, useForm } from 'react-h
 import { Box, Button, Grid, Typography } from '@mui/material'
 import LoadingButton from '@mui/lab/LoadingButton'
 import { SaveShortcut } from '../../../../components/form/SaveShortcut'
-import React from 'react'
+import React, { useEffect, useRef } from 'react'
 import { useFirestoreDocumentMutation } from '../../../../services/hooks/firestoreMutationHooks'
 import { doc } from 'firebase/firestore'
 import { collections } from '../../../../services/firebase'
@@ -10,7 +10,13 @@ import { Event, EventAISettings } from '../../../../types'
 import { GenerateSessionsTeasingContentPrompts } from '../../../actions/sessions/generation/generateSessionTeasingContent'
 import { BASE_OPENROUTER_SETTINGS, useAiModelList } from '../../../../services/openRouter'
 
-export const SessionAISettings = ({ event }: { event: Event }) => {
+export const SessionAISettings = ({
+    event,
+    onValuesChange,
+}: {
+    event: Event
+    onValuesChange?: (values: EventAISettings) => void
+}) => {
     const mutation = useFirestoreDocumentMutation(doc(collections.events, event.id))
 
     const formContext = useForm({
@@ -25,6 +31,35 @@ export const SessionAISettings = ({ event }: { event: Event }) => {
     })
     const modelList = useAiModelList(event.openRouterAPIKey || '')
     const { formState } = formContext
+
+    // Forward unsaved form values upward so callers (e.g. the teasing dialog's
+    // "Generate preview") can run a generation against what's currently in the
+    // inputs without forcing the user to Save first.
+    const onValuesChangeRef = useRef(onValuesChange)
+    onValuesChangeRef.current = onValuesChange
+    useEffect(() => {
+        if (!onValuesChangeRef.current) return
+        const toSettings = (v: {
+            teasingPromptSystem?: string
+            teasingPromptUser?: string
+            model?: string
+            temperature?: string | number
+        }): EventAISettings => ({
+            model: v.model ?? '',
+            temperature: `${v.temperature ?? ''}`,
+            sessions: {
+                teasingPromptSystem: v.teasingPromptSystem ?? '',
+                teasingPromptUser: v.teasingPromptUser ?? '',
+            },
+        })
+        // Seed parent with the current values, then keep it in sync.
+        onValuesChangeRef.current(toSettings(formContext.getValues()))
+        const subscription = formContext.watch((value) => {
+            if (!onValuesChangeRef.current) return
+            onValuesChangeRef.current(toSettings(value))
+        })
+        return () => subscription.unsubscribe()
+    }, [formContext])
 
     return (
         <Box padding={2} borderRadius={2} border={1} borderColor="#66666688" mt={2} mb={2}>


### PR DESCRIPTION
## Summary

In the session teasing-content generation dialog, "Generate preview" used to silently run against the **persisted** AI settings — so any edit to the system prompt, user prompt, model, or temperature in the form had to be **Saved** before the preview button would actually try them. That made iterating on a prompt awkward.

`GenerateSessionsTextContentDialog` built `llmSettings.aiSettings` from `event.aiSettings`, which is the value last written to Firestore. `SessionAISettings` keeps user edits in its own `react-hook-form` state until the user clicks Save, so the dialog never saw the in-flight values.

This PR has `SessionAISettings` forward its live form values to the parent via an optional `onValuesChange` callback:
- Seeded on mount with `formContext.getValues()` so the dialog starts from the same values the form is rendering.
- Kept in sync afterwards via react-hook-form's `watch` subscription (cleaned up on unmount).
- The callback ref is updated each render so a stale closure can't fire after the parent re-renders.

The dialog mirrors those into a `liveAiSettings` state and uses it when calling `generate(...)`, so the preview always reflects whatever's currently in the inputs — no Save required.

## Test plan

- [ ] Open the teasing generation dialog from a session, edit the system or user prompt without saving, click **Generate preview** — preview should reflect the edited prompt.
- [ ] Change model and/or temperature without saving, click **Generate preview** — preview should use the new values.
- [ ] Click **Save**, then **Generate preview** — should still work (saved values match live values).
- [ ] Reset to default, then preview without saving — should preview against the default prompt.
- [ ] Reload the dialog, observe no extra render churn / no console warnings (subscription unsubscribes cleanly).

https://claude.ai/code/session_01UDvv7pcPvqQ65YgdiAkYqQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01UDvv7pcPvqQ65YgdiAkYqQ)_