### PR TITLE
Searchable model picker with prices and dynamic top picks

### DIFF
--- a/src/components/form/ModelAutocomplete.tsx
+++ b/src/components/form/ModelAutocomplete.tsx
@@ -1,0 +1,163 @@
+import { Autocomplete, Box, TextField, Typography } from '@mui/material'
+import * as React from 'react'
+import { Controller, FieldValues, Path, useFormContext } from 'react-hook-form'
+import { getTopModelIds, OpenRouterModel } from '../../services/openRouter'
+
+const TOP_GROUP = 'Top picks'
+const ALL_GROUP = 'All models'
+
+type ModelAutocompleteProps<T extends FieldValues> = {
+    name: Path<T>
+    label: string
+    helperText?: string
+    placeholder?: string
+    disabled?: boolean
+    required?: boolean
+    models: OpenRouterModel[]
+    margin?: 'none' | 'dense' | 'normal'
+    variant?: 'standard' | 'filled' | 'outlined'
+}
+
+type Option = { id: string; isTop: boolean; model: OpenRouterModel }
+
+// Convert OpenRouter's per-token price (USD per token, given as a string) into
+// a short "$X" string per million tokens — what users actually compare across
+// providers.
+const formatPricePerMillion = (perTokenStr: string | undefined): string | null => {
+    if (perTokenStr == null) return null
+    const n = Number(perTokenStr)
+    if (!Number.isFinite(n)) return null
+    if (n === 0) return '$0'
+    const perMillion = n * 1_000_000
+    let formatted: string
+    if (perMillion >= 1) formatted = perMillion.toFixed(2).replace(/\.?0+$/, '')
+    else if (perMillion >= 0.01) formatted = perMillion.toFixed(3).replace(/\.?0+$/, '')
+    else formatted = perMillion.toExponential(1)
+    return `$${formatted}`
+}
+
+const formatPricing = (m: OpenRouterModel): string => {
+    const inPrice = formatPricePerMillion(m.pricing?.prompt) ?? '?'
+    const outPrice = formatPricePerMillion(m.pricing?.completion) ?? '?'
+    return `${inPrice} in / ${outPrice} out · /Mtok`
+}
+
+const formatCreated = (created: number | undefined): string | null => {
+    if (!created) return null
+    const d = new Date(created * 1000)
+    if (Number.isNaN(d.getTime())) return null
+    return d.toISOString().slice(0, 10)
+}
+
+export function ModelAutocomplete<T extends FieldValues>({
+    name,
+    label,
+    helperText,
+    placeholder,
+    disabled,
+    required,
+    models,
+    margin = 'dense',
+    variant = 'filled',
+}: ModelAutocompleteProps<T>) {
+    const { control } = useFormContext<T>()
+    const topIds = React.useMemo(() => getTopModelIds(models), [models])
+
+    const options = React.useMemo<Option[]>(() => {
+        const enriched: Option[] = models.map((m) => ({
+            id: m.id,
+            isTop: topIds.has(m.id),
+            model: m,
+        }))
+        // "Top picks" first (sorted most-recent within the group), then the
+        // long tail alphabetically.
+        enriched.sort((a, b) => {
+            if (a.isTop !== b.isTop) return a.isTop ? -1 : 1
+            if (a.isTop && b.isTop) {
+                return (b.model.created ?? 0) - (a.model.created ?? 0)
+            }
+            return a.id.localeCompare(b.id)
+        })
+        return enriched
+    }, [models, topIds])
+
+    return (
+        <Controller
+            name={name}
+            control={control}
+            rules={{ required }}
+            render={({ field: { value, onChange, onBlur, ref }, fieldState: { error } }) => {
+                const stringValue = typeof value === 'string' ? value : ''
+                const matched = options.find((o) => o.id === stringValue)
+                return (
+                    <Autocomplete<Option, false, false, true>
+                        freeSolo
+                        autoHighlight
+                        options={options}
+                        disabled={disabled}
+                        value={matched ?? stringValue}
+                        onChange={(_, next) => {
+                            if (next == null) onChange('')
+                            else if (typeof next === 'string') onChange(next)
+                            else onChange(next.id)
+                        }}
+                        onInputChange={(_, input, reason) => {
+                            // Keep the form value in sync with raw input so a
+                            // user-pasted id (not in the list) is captured.
+                            if (reason === 'input') onChange(input)
+                            if (reason === 'clear') onChange('')
+                        }}
+                        onBlur={onBlur}
+                        isOptionEqualToValue={(option, val) =>
+                            typeof val === 'string' ? option.id === val : option.id === val.id
+                        }
+                        getOptionLabel={(option) => (typeof option === 'string' ? option : option.id)}
+                        groupBy={(option) => (option.isTop ? TOP_GROUP : ALL_GROUP)}
+                        renderOption={(props, option) => {
+                            const m = option.model
+                            const date = formatCreated(m.created)
+                            return (
+                                <Box component="li" {...props} key={option.id}>
+                                    <Box sx={{ display: 'flex', flexDirection: 'column', flexGrow: 1, minWidth: 0 }}>
+                                        <Typography
+                                            variant="body2"
+                                            sx={{
+                                                fontWeight: option.isTop ? 600 : 400,
+                                                whiteSpace: 'nowrap',
+                                                overflow: 'hidden',
+                                                textOverflow: 'ellipsis',
+                                            }}>
+                                            {m.name || m.id}
+                                        </Typography>
+                                        <Typography
+                                            variant="caption"
+                                            color="text.secondary"
+                                            sx={{ display: 'block', fontSize: '0.7rem' }}>
+                                            {m.id}
+                                            {date ? ` · ${date}` : ''} · {formatPricing(m)}
+                                        </Typography>
+                                    </Box>
+                                </Box>
+                            )
+                        }}
+                        renderInput={(params) => (
+                            <TextField
+                                {...params}
+                                inputRef={ref}
+                                margin={margin}
+                                variant={variant}
+                                label={label}
+                                placeholder={placeholder}
+                                helperText={error?.message ?? helperText}
+                                error={!!error}
+                                required={required}
+                                disabled={disabled}
+                                fullWidth
+                            />
+                        )}
+                    />
+                )
+            }}
+        />
+    )
+}

--- a/src/components/form/ModelAutocomplete.tsx
+++ b/src/components/form/ModelAutocomplete.tsx
@@ -1,10 +1,12 @@
-import { Autocomplete, Box, TextField, Typography } from '@mui/material'
+import { Autocomplete, Box, createFilterOptions, TextField, Typography } from '@mui/material'
 import * as React from 'react'
 import { Controller, FieldValues, Path, useFormContext } from 'react-hook-form'
 import { getTopModelIds, OpenRouterModel } from '../../services/openRouter'
 
 const TOP_GROUP = 'Top picks'
 const ALL_GROUP = 'All models'
+
+type Option = { id: string; isTop: boolean; model: OpenRouterModel }
 
 type ModelAutocompleteProps<T extends FieldValues> = {
     name: Path<T>
@@ -18,7 +20,11 @@ type ModelAutocompleteProps<T extends FieldValues> = {
     variant?: 'standard' | 'filled' | 'outlined'
 }
 
-type Option = { id: string; isTop: boolean; model: OpenRouterModel }
+// Match against both the human-readable name and the id, so typing "claude"
+// finds "anthropic/claude-sonnet-4" and typing the slug works too.
+const filterOptions = createFilterOptions<Option>({
+    stringify: (option) => `${option.model.name ?? ''} ${option.id}`,
+})
 
 // Convert OpenRouter's per-token price (USD per token, given as a string) into
 // a short "$X" string per million tokens — what users actually compare across
@@ -69,17 +75,21 @@ export function ModelAutocomplete<T extends FieldValues>({
             isTop: topIds.has(m.id),
             model: m,
         }))
-        // "Top picks" first (sorted most-recent within the group), then the
-        // long tail alphabetically.
+        // "Top picks" first, alphabetical within each group.
         enriched.sort((a, b) => {
             if (a.isTop !== b.isTop) return a.isTop ? -1 : 1
-            if (a.isTop && b.isTop) {
-                return (b.model.created ?? 0) - (a.model.created ?? 0)
-            }
             return a.id.localeCompare(b.id)
         })
         return enriched
     }, [models, topIds])
+
+    // O(1) id -> option lookup so the controller renderer doesn't linearly
+    // scan the (potentially ~300-entry) catalog on every keystroke.
+    const optionsById = React.useMemo(() => {
+        const map = new Map<string, Option>()
+        for (const o of options) map.set(o.id, o)
+        return map
+    }, [options])
 
     return (
         <Controller
@@ -88,12 +98,13 @@ export function ModelAutocomplete<T extends FieldValues>({
             rules={{ required }}
             render={({ field: { value, onChange, onBlur, ref }, fieldState: { error } }) => {
                 const stringValue = typeof value === 'string' ? value : ''
-                const matched = options.find((o) => o.id === stringValue)
+                const matched = optionsById.get(stringValue)
                 return (
                     <Autocomplete<Option, false, false, true>
                         freeSolo
                         autoHighlight
                         options={options}
+                        filterOptions={filterOptions}
                         disabled={disabled}
                         value={matched ?? stringValue}
                         onChange={(_, next) => {

--- a/src/events/page/sessions/components/SessionAISettings.tsx
+++ b/src/events/page/sessions/components/SessionAISettings.tsx
@@ -1,4 +1,5 @@
-import { FormContainer, SelectElement, TextFieldElement, useForm } from 'react-hook-form-mui'
+import { FormContainer, TextFieldElement, useForm } from 'react-hook-form-mui'
+import { ModelAutocomplete } from '../../../../components/form/ModelAutocomplete'
 import { Box, Button, Grid, Typography } from '@mui/material'
 import LoadingButton from '@mui/lab/LoadingButton'
 import { SaveShortcut } from '../../../../components/form/SaveShortcut'
@@ -113,16 +114,13 @@ export const SessionAISettings = ({
                         />
                     </Grid>
                     <Grid item xs={12} sm={6}>
-                        <SelectElement
-                            margin="dense"
-                            required
-                            fullWidth
-                            label="Model"
+                        <ModelAutocomplete
                             name="model"
+                            label="Model"
                             helperText="See model list at https://openrouter.ai/models"
-                            variant="filled"
                             disabled={formState.isSubmitting}
-                            options={modelList.map((m) => ({ id: m.id, label: m.id }))}
+                            required
+                            models={modelList}
                         />
                         <TextFieldElement
                             margin="dense"

--- a/src/events/page/settings/EventSettings.tsx
+++ b/src/events/page/settings/EventSettings.tsx
@@ -65,7 +65,11 @@ export const EventSettings = ({ event }: EventSettingsProps) => {
         defaultValues: convertInputEvent(event),
     })
     const { control, formState, watch } = formContext
-    const modelList = useAiModelList(event.openRouterAPIKey || '')
+    // Drive the model list off the live form value so pasting a fresh API
+    // key into the field above immediately repopulates the picker, instead
+    // of staying empty until the user saves and reopens the page.
+    const openRouterAPIKey = watch('openRouterAPIKey') || ''
+    const modelList = useAiModelList(openRouterAPIKey)
 
     const days = diffDays(watch('dates.start'), watch('dates.end'))
 

--- a/src/events/page/settings/EventSettings.tsx
+++ b/src/events/page/settings/EventSettings.tsx
@@ -1,6 +1,8 @@
 import { yupResolver } from '@hookform/resolvers/yup'
 import { Box, Button, Card, Container, DialogContentText, Grid, Typography, IconButton, Collapse } from '@mui/material'
 import { FormContainer, TextFieldElement, useForm } from 'react-hook-form-mui'
+import { ModelAutocomplete } from '../../../components/form/ModelAutocomplete'
+import { useAiModelList } from '../../../services/openRouter'
 import LoadingButton from '@mui/lab/LoadingButton'
 import { doc } from 'firebase/firestore'
 import { DateTime } from 'luxon'
@@ -63,6 +65,7 @@ export const EventSettings = ({ event }: EventSettingsProps) => {
         defaultValues: convertInputEvent(event),
     })
     const { control, formState, watch } = formContext
+    const modelList = useAiModelList(event.openRouterAPIKey || '')
 
     const days = diffDays(watch('dates.start'), watch('dates.end'))
 
@@ -300,15 +303,13 @@ export const EventSettings = ({ event }: EventSettingsProps) => {
                                         helperText="Used for the in-app chat assistant. Get one at https://openrouter.ai/keys."
                                         disabled={formState.isSubmitting}
                                     />
-                                    <TextFieldElement
-                                        margin="normal"
-                                        fullWidth
-                                        id="openRouterModel"
-                                        label="OpenRouter model (optional)"
+                                    <ModelAutocomplete
                                         name="openRouterModel"
-                                        variant="filled"
+                                        label="OpenRouter model (optional)"
                                         helperText="Defaults to anthropic/claude-sonnet-4 if empty."
                                         disabled={formState.isSubmitting}
+                                        margin="normal"
+                                        models={modelList}
                                     />
                                     <TextFieldElement
                                         margin="normal"

--- a/src/services/openRouter.ts
+++ b/src/services/openRouter.ts
@@ -23,13 +23,26 @@ export const BASE_OPENROUTER_SETTINGS: OpenRouterCompletionSettings = {
     temperature: 0.3,
 }
 
-export const getAiModelList = async (apiKey: string) => {
-    openRouter.apiKey = apiKey
-    return openRouter.models.list().then((m) => m.getPaginatedItems())
+// OpenRouter returns richer fields than the OpenAI SDK types describe; the JS
+// payload preserves them, so we cast at the boundary.
+export interface OpenRouterModel {
+    id: string
+    name?: string
+    created?: number
+    pricing?: {
+        prompt?: string
+        completion?: string
+    }
 }
 
-export const useAiModelList = (apiKey: string) => {
-    const [models, setModels] = useState<OpenAI.Model[]>([])
+export const getAiModelList = async (apiKey: string): Promise<OpenRouterModel[]> => {
+    openRouter.apiKey = apiKey
+    const items = await openRouter.models.list().then((m) => m.getPaginatedItems())
+    return items as unknown as OpenRouterModel[]
+}
+
+export const useAiModelList = (apiKey: string): OpenRouterModel[] => {
+    const [models, setModels] = useState<OpenRouterModel[]>([])
     useEffect(() => {
         if (!apiKey) {
             setModels([])
@@ -40,4 +53,42 @@ export const useAiModelList = (apiKey: string) => {
             .catch(() => setModels([]))
     }, [apiKey])
     return models
+}
+
+const stripAlias = (id: string) => (id.startsWith('~') ? id.slice(1) : id)
+
+export const getProviderFromModelId = (id: string): string | null => {
+    const stripped = stripAlias(id)
+    const slash = stripped.indexOf('/')
+    return slash > 0 ? stripped.slice(0, slash) : null
+}
+
+// Surface the most relevant ~15 models without hardcoding any provider name:
+// 1. group concrete models (skip `~xxx/...-latest` aliases) by their provider
+//    prefix (the part before "/" in the id),
+// 2. take the 5 providers with the most models (ties broken alphabetically),
+// 3. and from each, pick the 3 most recently `created` model ids.
+export const getTopModelIds = (models: OpenRouterModel[]): Set<string> => {
+    const byProvider = new Map<string, OpenRouterModel[]>()
+    for (const m of models) {
+        if (!m?.id || m.id.startsWith('~')) continue
+        const provider = getProviderFromModelId(m.id)
+        if (!provider) continue
+        const list = byProvider.get(provider)
+        if (list) list.push(m)
+        else byProvider.set(provider, [m])
+    }
+    const topProviders = [...byProvider.entries()]
+        .sort((a, b) => b[1].length - a[1].length || a[0].localeCompare(b[0]))
+        .slice(0, 5)
+        .map(([provider]) => provider)
+    const result = new Set<string>()
+    for (const provider of topProviders) {
+        const recent = (byProvider.get(provider) ?? [])
+            .slice()
+            .sort((a, b) => (b.created ?? 0) - (a.created ?? 0))
+            .slice(0, 3)
+        for (const m of recent) result.add(m.id)
+    }
+    return result
 }


### PR DESCRIPTION
## Summary

Replaces the OpenRouter model field — a free-text `TextFieldElement` on the event settings page and a flat `SelectElement` on the session teasing AI settings — with a single `ModelAutocomplete` component used in both places.

The new picker is a searchable, freeSolo `Autocomplete` so users can either pick a known model from the live OpenRouter list or paste an arbitrary id (handy for org-specific models or new releases not in the cached list yet).

### Top picks, derived (no hardcoded provider list)

The list groups options into **Top picks** vs **All models**. The "Top picks" set is computed at render time from the live model list, with no hardcoded provider names:

1. Concrete models (excluding `~xxx/...-latest` aliases) are grouped by their provider prefix (the part before `/` in the id).
2. The 5 providers with the most models are kept (ties broken alphabetically) — this surfaces the major frontier-model labs in practice.
3. From each, the 3 most recently `created` model ids become the picks.

If OpenRouter changes its catalog, the highlights track it automatically.

### Pricing & date display

Each option shows its full name, id, release date, and per-Mtoken input/output price in a compact caption, e.g.:

```
Anthropic: Claude Sonnet 4
anthropic/claude-sonnet-4 · 2025-05-22 · $3 in / $15 out · /Mtok
```

The `OpenAI` SDK types had stripped `name`, `created`, and `pricing` from the `Models.list()` response even though the OpenRouter payload preserves them; this PR adds a richer `OpenRouterModel` type at the SDK boundary so the autocomplete and any future caller can use those fields directly.

### Files

- `src/services/openRouter.ts` — `OpenRouterModel` type, `useAiModelList` retypes, `getTopModelIds` helper, `getProviderFromModelId` helper.
- `src/components/form/ModelAutocomplete.tsx` — new component, react-hook-form-mui compatible (uses `useFormContext` + `Controller`), value is the model id string.
- `src/events/page/settings/EventSettings.tsx` — drop-in replacement for the `openRouterModel` text field.
- `src/events/page/sessions/components/SessionAISettings.tsx` — drop-in replacement for the model `SelectElement`.

## Test plan

- [ ] Open Event Settings with a valid OpenRouter API key — model field becomes an autocomplete; "Top picks" header lists ~15 recent models from 5 providers; each option shows id, date, and `$X in / $Y out · /Mtok`.
- [ ] Type to filter, pick a model, save, reload — selection persists.
- [ ] Paste an unknown model id, save, reload — the typed string persists (freeSolo).
- [ ] Open the session teasing generation dialog — same picker behavior; previously `Save` was needed for the dropdown to round-trip; preview now uses live form values.
- [ ] Without an OpenRouter API key — model list is empty; field still accepts free text and saves it.

https://claude.ai/code/session_01UDvv7pcPvqQ65YgdiAkYqQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01UDvv7pcPvqQ65YgdiAkYqQ)_