### PR TITLE
Add selected day to admin schedule URL

### DIFF
--- a/src/events/page/schedule/EventSchedule.tsx
+++ b/src/events/page/schedule/EventSchedule.tsx
@@ -1,6 +1,6 @@
 import { Box, Button, Card, Dialog, Link, Typography } from '@mui/material'
 import * as React from 'react'
-import { useRef, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { Event, Session } from '../../../types'
 import { useSessions } from '../../../services/hooks/useSessions'
 import { FirestoreQueryLoaderAndErrorDisplay } from '../../../components/FirestoreQueryLoaderAndErrorDisplay'
@@ -11,7 +11,7 @@ import { DateTime } from 'luxon'
 import { EventSourceInput } from '@fullcalendar/core'
 import { onFullCalendarEventChange } from './eventScheduleFunctions'
 import { SessionCardContent } from './components/SessionCardContent'
-import { useLocation } from 'wouter'
+import { useLocation, useSearchParams } from 'wouter'
 import { FullCalendarBase } from './components/FullCalendarBase'
 import { useSessionTemplate } from '../../../services/hooks/useSessionsTemplate'
 import { getSessionBackgroundColor } from './components/getSessionBackgroundColor'
@@ -25,16 +25,37 @@ import { useNotification } from '../../../hooks/notificationHook'
 export type EventScheduleProps = {
     event: Event
 }
+const DAY_URL_FORMAT = 'yyyy-MM-dd'
+
 export const EventSchedule = ({ event }: EventScheduleProps) => {
     const calendarRef = useRef(null)
     const templateCalendarRef = useRef(null)
     const numberOfDays = diffDays(event.dates.start, event.dates.end)
     const [_, setLocation] = useLocation()
+    const [searchParams, setSearchParams] = useSearchParams()
+    const dayParam = searchParams.get('day')
     const sessions = useSessions(event)
     const sessionsTemplate = useSessionTemplate(event)
     const [daysToDisplay, setDaysToDisplay] = useState<number>(1)
     const [exportDialogOpen, setExportDialogOpen] = useState(false)
     const { createNotification } = useNotification()
+
+    const initialDateRef = useRef<string | undefined>(undefined)
+    if (initialDateRef.current === undefined) {
+        const parsedDay = dayParam ? DateTime.fromFormat(dayParam, DAY_URL_FORMAT) : null
+        initialDateRef.current = parsedDay && parsedDay.isValid ? parsedDay.toISO() : event.dates.start?.toISOString()
+    }
+
+    useEffect(() => {
+        if (!dayParam) return
+        const parsed = DateTime.fromFormat(dayParam, DAY_URL_FORMAT)
+        if (!parsed.isValid) return
+        const targetDate = parsed.toJSDate()
+        const calendarApi = (calendarRef.current as any)?.getApi()
+        if (calendarApi && calendarApi.getDate().getTime() !== targetDate.getTime()) {
+            calendarApi.gotoDate(targetDate)
+        }
+    }, [dayParam])
 
     if (numberOfDays <= 0 || !event.dates.start || !event.dates.end) {
         return (
@@ -153,6 +174,7 @@ export const EventSchedule = ({ event }: EventScheduleProps) => {
                     startTime={startTime}
                     daysToDisplay={daysToDisplay}
                     event={event}
+                    initialDate={initialDateRef.current}
                     events={
                         sessionsWithDates.map((s: Session) => ({
                             title: s.title,
@@ -173,6 +195,18 @@ export const EventSchedule = ({ event }: EventScheduleProps) => {
                         )
                     }}
                     customButtons={customButtons}
+                    datesSet={(arg) => {
+                        const day = DateTime.fromJSDate(arg.start).toFormat(DAY_URL_FORMAT)
+                        if (day !== searchParams.get('day')) {
+                            const newParams = new URLSearchParams(searchParams)
+                            newParams.set('day', day)
+                            setSearchParams(newParams)
+                        }
+                        const templateApi = (templateCalendarRef.current as any)?.getApi()
+                        if (templateApi && templateApi.getDate().getTime() !== arg.start.getTime()) {
+                            templateApi.gotoDate(arg.start)
+                        }
+                    }}
                     drop={(info) => {
                         const sessionId = info.draggedEl.getAttribute('data-id')
                         const trackId = info.resource?.id
@@ -214,6 +248,7 @@ export const EventSchedule = ({ event }: EventScheduleProps) => {
                             event={event}
                             daysToDisplay={daysToDisplay}
                             startTime={startTime}
+                            initialDate={initialDateRef.current}
                             events={sessionsTemplateArray.map((template) => {
                                 return {
                                     title: template.title,

--- a/src/events/page/schedule/EventSchedule.tsx
+++ b/src/events/page/schedule/EventSchedule.tsx
@@ -43,7 +43,8 @@ export const EventSchedule = ({ event }: EventScheduleProps) => {
     const initialDateRef = useRef<string | undefined>(undefined)
     if (initialDateRef.current === undefined) {
         const parsedDay = dayParam ? DateTime.fromFormat(dayParam, DAY_URL_FORMAT) : null
-        initialDateRef.current = parsedDay && parsedDay.isValid ? parsedDay.toISO() : event.dates.start?.toISOString()
+        const parsedDayISO = parsedDay && parsedDay.isValid ? parsedDay.toISO() : null
+        initialDateRef.current = parsedDayISO ?? event.dates.start?.toISOString()
     }
 
     useEffect(() => {

--- a/src/events/page/schedule/components/FullCalendarBase.tsx
+++ b/src/events/page/schedule/components/FullCalendarBase.tsx
@@ -11,6 +11,7 @@ type FullCalendarBaseProps = {
     events: EventSourceInput
     daysToDisplay: number
     startTime: string
+    initialDate?: string
     customButtons?: Record<string, any>
     drop?: (arg: DropArg) => void
     eventDrop?: (arg: EventDropArg) => void
@@ -28,6 +29,7 @@ export const FullCalendarBase = ({
     events,
     startTime,
     daysToDisplay,
+    initialDate,
     customButtons,
     drop,
     eventDrop,
@@ -53,7 +55,7 @@ export const FullCalendarBase = ({
             }}
             customButtons={customButtons}
             initialView="resourceTimeGridFourDay"
-            initialDate={event.dates.start?.toISOString()}
+            initialDate={initialDate ?? event.dates.start?.toISOString()}
             validRange={{
                 start: event.dates.start?.toISOString(),
                 end: event.dates.end?.toISOString(),


### PR DESCRIPTION
## Summary
- The admin schedule page (`/events/:eventId/schedule`) now reflects the currently displayed day in a `?day=yyyy-MM-dd` query param.
- The URL is updated whenever the user navigates the calendar (prev/next), and the calendar opens on the day from the URL when present.
- Makes admin schedule URLs shareable and bookmarkable per-day, and lets the back/forward browser buttons navigate days.

## Implementation
- `FullCalendarBase` now accepts an optional `initialDate` prop, defaulting to the event start (preserving previous behavior for any caller that doesn't pass it).
- `EventSchedule` reads/writes `?day=` via wouter's `useSearchParams`:
  - Initial render: parses the URL day (falls back to event start).
  - `datesSet` on the main calendar: writes the visible start day into the URL and syncs the underlay template calendar.
  - `useEffect` on URL change: navigates the calendar when the user uses back/forward.

## Test plan
- [ ] Open `/events/:eventId/schedule` for a multi-day event - URL should update to `?day=YYYY-MM-DD` after the calendar renders.
- [ ] Click the calendar's next/prev buttons - URL should update to reflect the new day.
- [ ] Visit `/events/:eventId/schedule?day=YYYY-MM-DD` directly - the calendar should open on that day.
- [ ] Use the browser's back/forward buttons - the calendar should follow the URL.
- [ ] Toggle "Display all days" - URL should still reflect the first visible day.
- [ ] With a template overlay (event has session templates) - main and template calendars stay synced when navigating.

---
_Generated by [Claude Code](https://claude.ai/code/session_0162rr6NBdFMSzHwudX3tNWV)_