### PR TITLE
Categorize and restyle the events home

### DIFF
--- a/src/events/list/EventsListItem.tsx
+++ b/src/events/list/EventsListItem.tsx
@@ -1,16 +1,76 @@
 import * as React from 'react'
 import { Event } from '../../types'
-import { Box, Button, Link } from '@mui/material'
+import { Avatar, Box, Card, Stack, Typography } from '@mui/material'
+import { Link } from 'wouter'
+import { DateTime } from 'luxon'
+import EventIcon from '@mui/icons-material/Event'
 
 export type EventsListItemProps = {
     event: Event
 }
+
+const formatDateRange = (start: Date | null, end: Date | null): string | null => {
+    if (!start && !end) return null
+    const startDT = start ? DateTime.fromJSDate(start) : null
+    const endDT = end ? DateTime.fromJSDate(end) : null
+    if (startDT && endDT) {
+        if (startDT.hasSame(endDT, 'day')) return startDT.toLocaleString(DateTime.DATE_MED)
+        const sameYear = startDT.hasSame(endDT, 'year')
+        return `${startDT.toLocaleString({ month: 'short', day: 'numeric' })} – ${endDT.toLocaleString(
+            sameYear ? { month: 'short', day: 'numeric' } : DateTime.DATE_MED
+        )}, ${endDT.year}`
+    }
+    return (startDT ?? endDT)!.toLocaleString(DateTime.DATE_MED)
+}
+
 export const EventsListItem = ({ event }: EventsListItemProps) => {
+    const dateRange = formatDateRange(event.dates.start, event.dates.end)
+    const accentColor = event.color || undefined
+
     return (
-        <Box component="li" marginRight={1} marginBottom={1} sx={{ listStyle: 'none' }}>
-            <Button component={Link} variant="contained" href={`/events/${event.id}`} size="large">
-                {event.name}
-            </Button>
-        </Box>
+        <Link
+            href={`/events/${event.id}`}
+            style={{ textDecoration: 'none', display: 'block', width: '100%', height: '100%' }}>
+            <Card
+                variant="outlined"
+                sx={{
+                    height: '100%',
+                    p: 2,
+                    borderLeft: accentColor ? `4px solid ${accentColor}` : undefined,
+                    transition: 'background-color 0.15s ease, transform 0.15s ease',
+                    cursor: 'pointer',
+                    '&:hover': {
+                        bgcolor: 'action.hover',
+                    },
+                }}>
+                <Stack direction="row" spacing={2} alignItems="center">
+                    {event.logoUrl ? (
+                        <Avatar
+                            src={event.logoUrl}
+                            alt={event.name}
+                            variant="rounded"
+                            sx={{ width: 48, height: 48, bgcolor: 'transparent' }}
+                        />
+                    ) : (
+                        <Avatar
+                            variant="rounded"
+                            sx={{ width: 48, height: 48, bgcolor: accentColor || 'primary.main' }}>
+                            {event.name.charAt(0).toUpperCase()}
+                        </Avatar>
+                    )}
+                    <Box sx={{ flexGrow: 1, minWidth: 0 }}>
+                        <Typography variant="subtitle1" fontWeight={600} noWrap title={event.name} color="text.primary">
+                            {event.name}
+                        </Typography>
+                        <Stack direction="row" spacing={0.5} alignItems="center" sx={{ color: 'text.secondary' }}>
+                            <EventIcon fontSize="inherit" />
+                            <Typography variant="body2" noWrap>
+                                {dateRange ?? 'No date set'}
+                            </Typography>
+                        </Stack>
+                    </Box>
+                </Stack>
+            </Card>
+        </Link>
     )
 }

--- a/src/events/list/EventsScreen.tsx
+++ b/src/events/list/EventsScreen.tsx
@@ -83,11 +83,7 @@ export const EventsScreen = ({}) => {
                 )
             })}
 
-            <Alert severity="info" sx={{ mt: 4 }}>
-                ConferenceHall integration is now directly managed within ConferenceHall, using OpenPlanner API key.
-            </Alert>
-
-            <Box display="flex" flexDirection="column" alignItems="center" gap={1} maxWidth={500} marginX="auto" mt={2}>
+            <Box display="flex" flexDirection="column" alignItems="center" gap={1} maxWidth={500} marginX="auto" mt={4}>
                 <Typography>
                     This project is open source on{' '}
                     <Link component="a" href="https://github.com/HugoGresse/openplanner" target="_blank">

--- a/src/events/list/EventsScreen.tsx
+++ b/src/events/list/EventsScreen.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useMemo, useState } from 'react'
 import { EventsLayout } from './EventsLayout'
 import { useEvents } from '../../services/hooks/useEvents'
 import { useSelector } from 'react-redux'
@@ -6,12 +6,15 @@ import { selectUserIdOpenPlanner } from '../../auth/authReducer'
 import { FirestoreQueryLoaderAndErrorDisplay } from '../../components/FirestoreQueryLoaderAndErrorDisplay'
 import { EventsListItem } from './EventsListItem'
 import { Event } from '../../types'
-import { Alert, Box, Button, Link, Typography } from '@mui/material'
+import { Alert, Box, Button, Chip, Divider, Grid, Link, Stack, Typography } from '@mui/material'
+import AddIcon from '@mui/icons-material/Add'
 import { NewEventCreatedDialog } from '../new/NewEventCreatedDialog'
 import { useNotification } from '../../hooks/notificationHook'
 import { NewEventDialog } from '../new/NewEventDialog'
 import { useIsAdmin } from '../../services/hooks/useIsAdmin'
 import { OSSSponsor } from '../../components/OSSSponsor'
+import { EVENT_CATEGORY_LABEL, EVENT_CATEGORY_ORDER, groupEventsByCategory } from './categorizeEvents'
+
 export const EventsScreen = ({}) => {
     const userId = useSelector(selectUserIdOpenPlanner)
     const events = useEvents(userId)
@@ -20,6 +23,9 @@ export const EventsScreen = ({}) => {
     const isAdmin = useIsAdmin(userId)
 
     const { createNotification } = useNotification()
+
+    const groupedEvents = useMemo(() => groupEventsByCategory((events.data || []) as Event[]), [events.data])
+    const totalEvents = (events.data || []).length
 
     const onEventCreated = (eventId: string | null) => {
         if (eventId) {
@@ -33,24 +39,51 @@ export const EventsScreen = ({}) => {
         <EventsLayout>
             <FirestoreQueryLoaderAndErrorDisplay hookResult={events} />
 
-            <Box component="ul" display="flex" flexWrap="wrap" padding={0}>
-                <Box key="new" component="li" marginRight={1} marginBottom={1} sx={{ listStyle: 'none' }}>
-                    <Button variant="outlined" size="large" onClick={() => setNewEventOpen(true)}>
-                        New event
-                    </Button>
-                </Box>
-
-                {(events.data || []).map((event: Event) => (
-                    <EventsListItem event={event} key={event.id} />
-                ))}
-            </Box>
-            {isAdmin && (
-                <Button variant="outlined" size="large" href="/admins">
-                    ADMIN
+            <Stack
+                direction="row"
+                alignItems="center"
+                justifyContent="space-between"
+                sx={{ mb: 3, flexWrap: 'wrap', gap: 1 }}>
+                <Button variant="contained" size="large" startIcon={<AddIcon />} onClick={() => setNewEventOpen(true)}>
+                    New event
                 </Button>
+                {isAdmin && (
+                    <Button variant="outlined" size="large" href="/admins">
+                        Admin
+                    </Button>
+                )}
+            </Stack>
+
+            {totalEvents === 0 && !events.isLoading && (
+                <Alert severity="info" sx={{ mb: 2 }}>
+                    You don't have any event yet. Create one to get started.
+                </Alert>
             )}
 
-            <Alert severity="info">
+            {EVENT_CATEGORY_ORDER.map((category) => {
+                const list = groupedEvents[category]
+                if (!list.length) return null
+                return (
+                    <Box key={category} sx={{ mb: 4 }}>
+                        <Stack direction="row" alignItems="center" spacing={1} sx={{ mb: 1.5 }}>
+                            <Typography variant="h6" component="h3" sx={{ fontWeight: 600 }}>
+                                {EVENT_CATEGORY_LABEL[category]}
+                            </Typography>
+                            <Chip label={list.length} size="small" />
+                        </Stack>
+                        <Divider sx={{ mb: 2 }} />
+                        <Grid container spacing={2}>
+                            {list.map((event) => (
+                                <Grid item xs={12} sm={6} md={6} key={event.id}>
+                                    <EventsListItem event={event} />
+                                </Grid>
+                            ))}
+                        </Grid>
+                    </Box>
+                )
+            })}
+
+            <Alert severity="info" sx={{ mt: 4 }}>
                 ConferenceHall integration is now directly managed within ConferenceHall, using OpenPlanner API key.
             </Alert>
 

--- a/src/events/list/categorizeEvents.ts
+++ b/src/events/list/categorizeEvents.ts
@@ -1,0 +1,46 @@
+import { Event } from '../../types'
+
+export type EventCategory = 'active' | 'upcoming' | 'past' | 'unscheduled'
+
+export const EVENT_CATEGORY_ORDER: EventCategory[] = ['active', 'upcoming', 'unscheduled', 'past']
+
+export const EVENT_CATEGORY_LABEL: Record<EventCategory, string> = {
+    active: 'Happening now',
+    upcoming: 'Upcoming',
+    unscheduled: 'Without dates',
+    past: 'Past',
+}
+
+export const getEventCategory = (event: Event, now: Date = new Date()): EventCategory => {
+    const { start, end } = event.dates
+    if (!start && !end) return 'unscheduled'
+    if (start && end && start.getTime() <= now.getTime() && now.getTime() <= end.getTime()) return 'active'
+    if (start && start.getTime() > now.getTime()) return 'upcoming'
+    if (end && end.getTime() < now.getTime()) return 'past'
+    return 'unscheduled'
+}
+
+export const groupEventsByCategory = (events: Event[]): Record<EventCategory, Event[]> => {
+    const groups: Record<EventCategory, Event[]> = {
+        active: [],
+        upcoming: [],
+        unscheduled: [],
+        past: [],
+    }
+    const now = new Date()
+    for (const event of events) {
+        groups[getEventCategory(event, now)].push(event)
+    }
+    groups.active.sort(byStartAscending)
+    groups.upcoming.sort(byStartAscending)
+    groups.past.sort(byStartDescending)
+    groups.unscheduled.sort(byNameAscending)
+    return groups
+}
+
+const byStartAscending = (a: Event, b: Event) =>
+    (a.dates.start?.getTime() ?? Number.POSITIVE_INFINITY) - (b.dates.start?.getTime() ?? Number.POSITIVE_INFINITY)
+
+const byStartDescending = (a: Event, b: Event) => (b.dates.start?.getTime() ?? 0) - (a.dates.start?.getTime() ?? 0)
+
+const byNameAscending = (a: Event, b: Event) => a.name.localeCompare(b.name)

--- a/src/events/list/categorizeEvents.ts
+++ b/src/events/list/categorizeEvents.ts
@@ -12,12 +12,16 @@ export const EVENT_CATEGORY_LABEL: Record<EventCategory, string> = {
 }
 
 export const getEventCategory = (event: Event, now: Date = new Date()): EventCategory => {
-    const { start, end } = event.dates
-    if (!start && !end) return 'unscheduled'
-    if (start && end && start.getTime() <= now.getTime() && now.getTime() <= end.getTime()) return 'active'
-    if (start && start.getTime() > now.getTime()) return 'upcoming'
-    if (end && end.getTime() < now.getTime()) return 'past'
-    return 'unscheduled'
+    const startMs = event.dates.start?.getTime() ?? null
+    const endMs = event.dates.end?.getTime() ?? null
+    if (startMs === null && endMs === null) return 'unscheduled'
+    const nowMs = now.getTime()
+    if (startMs !== null && endMs !== null) {
+        if (startMs <= nowMs && nowMs <= endMs) return 'active'
+        return startMs > nowMs ? 'upcoming' : 'past'
+    }
+    if (startMs !== null) return startMs > nowMs ? 'upcoming' : 'past'
+    return endMs! < nowMs ? 'past' : 'upcoming'
 }
 
 export const groupEventsByCategory = (events: Event[]): Record<EventCategory, Event[]> => {


### PR DESCRIPTION
## Summary
- Redesigned events home: the flat list of buttons is replaced with a card grid grouped by event status — _Happening now_, _Upcoming_, _Without dates_, _Past_. Each card shows the event logo (or a tinted initial avatar), the formatted date range, and a colored left border using `event.color`. Sections with no events are hidden.

## Implementation
- `src/events/list/categorizeEvents.ts` (new): categorizes events into `active` / `upcoming` / `unscheduled` / `past` and sorts each group (chronological for upcoming, reverse-chronological for past, alphabetic for unscheduled).
- `src/events/list/EventsListItem.tsx`: rebuilt as a `Card` with logo/avatar, name, date range, and a colored left border using `event.color`. Uses wouter's `Link` for soft navigation (matching the existing `SessionItem` pattern).
- `src/events/list/EventsScreen.tsx`: top action row (New event / Admin), then one section per non-empty category with a count chip and a responsive grid.

## Test plan
- [ ] Open the events home — events are grouped by status; the most prominent groupings (Happening now / Upcoming) appear first.
- [ ] Create a new event with a future date — appears under "Upcoming".
- [ ] Create one with no dates — appears under "Without dates".
- [ ] An event whose end date is in the past — appears under "Past".
- [ ] Empty sections don't render.