### PR TITLE
Split Mailgun SMTP env var into discrete host/port/user/password

### DIFF
--- a/functions/.env.example
+++ b/functions/.env.example
@@ -5,10 +5,16 @@ CAP_SECRET=xxx
 CAP_VERIFY_URL=xxx
 PUBLIC_APP_URL=https://openplanner.fr
 
-# Mailgun SMTP connection URI used by the speaker self-edit email flow.
-# URL-encode special characters in the user/password (e.g. `@` -> `%40`).
-# Use smtps:// for port 465 (implicit TLS) or smtp:// for 587 (STARTTLS).
-MAILGUN_SMTP_URI=smtps://postmaster%40mg.example.com:YOUR_SMTP_PASSWORD@smtp.eu.mailgun.org:465
+# Mailgun SMTP settings used by the speaker self-edit email flow.
+# Each component is its own env var so neither the user nor the password
+# ever needs URL encoding (the previous single-URI shape tripped on `@`
+# in the Mailgun username).
+#
+# Use port 465 for implicit TLS (default) or 587 for STARTTLS.
+MAILGUN_SMTP_HOST=smtp.eu.mailgun.org
+MAILGUN_SMTP_PORT=465
+MAILGUN_SMTP_USER=postmaster@mg.example.com
+MAILGUN_SMTP_PASSWORD=YOUR_SMTP_PASSWORD
 
 # From header used on every outbound email. Either a bare address or
 # "Display Name <addr@example.com>".

--- a/functions/src/api/other/sendEmail.test.ts
+++ b/functions/src/api/other/sendEmail.test.ts
@@ -32,12 +32,18 @@ describe('sendEmail', () => {
         nodemailerMocks.sendMail.mockReset()
         nodemailerMocks.createTransport.mockReset()
         nodemailerMocks.createTransport.mockReturnValue({ sendMail: nodemailerMocks.sendMail })
-        process.env.MAILGUN_SMTP_URI = 'smtps://u:p@smtp.example.com:465'
+        process.env.MAILGUN_SMTP_HOST = 'smtp.example.com'
+        process.env.MAILGUN_SMTP_PORT = '465'
+        process.env.MAILGUN_SMTP_USER = 'postmaster@mg.example.com'
+        process.env.MAILGUN_SMTP_PASSWORD = 'secret'
         process.env.MAIL_FROM = 'OpenPlanner <noreply@mg.example.com>'
     })
 
     afterEach(() => {
-        delete process.env.MAILGUN_SMTP_URI
+        delete process.env.MAILGUN_SMTP_HOST
+        delete process.env.MAILGUN_SMTP_PORT
+        delete process.env.MAILGUN_SMTP_USER
+        delete process.env.MAILGUN_SMTP_PASSWORD
         delete process.env.MAIL_FROM
     })
 
@@ -92,8 +98,8 @@ describe('sendEmail', () => {
         expect(delivery.error).toMatch(/ECONNREFUSED/)
     })
 
-    test('throws if MAILGUN_SMTP_URI is missing', async () => {
-        delete process.env.MAILGUN_SMTP_URI
+    test('throws if Mailgun SMTP env vars are missing', async () => {
+        delete process.env.MAILGUN_SMTP_HOST
         const setSpy = vi.fn(() => Promise.resolve())
         const addSpy = vi.fn()
         await expect(
@@ -102,7 +108,44 @@ describe('sendEmail', () => {
                 subject: 'X',
                 text: 'X',
             })
-        ).rejects.toThrow(/MAILGUN_SMTP_URI/)
+        ).rejects.toThrow(/MAILGUN_SMTP_HOST/)
+    })
+
+    test('builds the nodemailer transport with discrete host/port/user/pass options', async () => {
+        const setSpy = vi.fn(() => Promise.resolve())
+        const addSpy = vi.fn()
+        nodemailerMocks.sendMail.mockResolvedValueOnce({ messageId: 'mid-3', response: '250 OK' })
+
+        await sendEmail(makeFirebaseApp(setSpy, addSpy), {
+            to: 'jane@example.com',
+            subject: 'Hello',
+            text: 'body',
+        })
+        expect(nodemailerMocks.createTransport).toHaveBeenCalledOnce()
+        const opts = nodemailerMocks.createTransport.mock.calls[0][0]
+        expect(opts).toMatchObject({
+            host: 'smtp.example.com',
+            port: 465,
+            secure: true,
+            auth: { user: 'postmaster@mg.example.com', pass: 'secret' },
+            pool: true,
+        })
+    })
+
+    test('uses STARTTLS (secure=false) on port 587', async () => {
+        __resetEmailTransporterForTests()
+        process.env.MAILGUN_SMTP_PORT = '587'
+        const setSpy = vi.fn(() => Promise.resolve())
+        const addSpy = vi.fn()
+        nodemailerMocks.sendMail.mockResolvedValueOnce({ messageId: 'mid-4', response: '250 OK' })
+
+        await sendEmail(makeFirebaseApp(setSpy, addSpy), {
+            to: 'jane@example.com',
+            subject: 'Hi',
+            text: 'body',
+        })
+        const opts = nodemailerMocks.createTransport.mock.calls[0][0]
+        expect(opts).toMatchObject({ port: 587, secure: false })
     })
 
     test('writes ERROR delivery when MAIL_FROM is missing', async () => {

--- a/functions/src/api/other/sendEmail.test.ts
+++ b/functions/src/api/other/sendEmail.test.ts
@@ -132,7 +132,7 @@ describe('sendEmail', () => {
         })
     })
 
-    test('uses STARTTLS (secure=false) on port 587', async () => {
+    test('uses STARTTLS (secure=false) with requireTLS on port 587', async () => {
         __resetEmailTransporterForTests()
         process.env.MAILGUN_SMTP_PORT = '587'
         const setSpy = vi.fn(() => Promise.resolve())
@@ -145,7 +145,57 @@ describe('sendEmail', () => {
             text: 'body',
         })
         const opts = nodemailerMocks.createTransport.mock.calls[0][0]
-        expect(opts).toMatchObject({ port: 587, secure: false })
+        // requireTLS forces the STARTTLS upgrade — without it nodemailer
+        // would silently fall back to plaintext if the server does not
+        // advertise STARTTLS, leaking the SMTP credentials.
+        expect(opts).toMatchObject({ port: 587, secure: false, requireTLS: true })
+    })
+
+    test('omits requireTLS on the implicit-TLS port (465 already secure)', async () => {
+        const setSpy = vi.fn(() => Promise.resolve())
+        const addSpy = vi.fn()
+        nodemailerMocks.sendMail.mockResolvedValueOnce({ messageId: 'mid-5', response: '250 OK' })
+
+        await sendEmail(makeFirebaseApp(setSpy, addSpy), {
+            to: 'jane@example.com',
+            subject: 'Hi',
+            text: 'body',
+        })
+        const opts = nodemailerMocks.createTransport.mock.calls[0][0]
+        expect(opts).toMatchObject({ port: 465, secure: true, requireTLS: false })
+    })
+
+    test.each([
+        ['empty string', ''],
+        ['non-numeric', 'abc'],
+        ['decimal', '587.5'],
+        ['zero', '0'],
+        ['too large', '70000'],
+        ['negative', '-1'],
+    ])('rejects an invalid MAILGUN_SMTP_PORT (%s)', async (_label, value) => {
+        __resetEmailTransporterForTests()
+        process.env.MAILGUN_SMTP_PORT = value
+        const setSpy = vi.fn(() => Promise.resolve())
+        const addSpy = vi.fn()
+        if (value === '') {
+            // empty string falls back to the default 465 path, so a send
+            // should succeed — verify rather than assert a throw.
+            nodemailerMocks.sendMail.mockResolvedValueOnce({ messageId: 'x', response: '250' })
+            await sendEmail(makeFirebaseApp(setSpy, addSpy), {
+                to: 'a@b.c',
+                subject: 'x',
+                text: 'x',
+            })
+            expect(nodemailerMocks.createTransport.mock.calls[0][0]).toMatchObject({ port: 465 })
+            return
+        }
+        await expect(
+            sendEmail(makeFirebaseApp(setSpy, addSpy), {
+                to: 'a@b.c',
+                subject: 'x',
+                text: 'x',
+            })
+        ).rejects.toThrow(/MAILGUN_SMTP_PORT/)
     })
 
     test('writes ERROR delivery when MAIL_FROM is missing', async () => {

--- a/functions/src/api/other/sendEmail.ts
+++ b/functions/src/api/other/sendEmail.ts
@@ -25,26 +25,39 @@ let cachedTransporter: Transporter | null = null
 
 const getTransporter = (): Transporter => {
     if (cachedTransporter) return cachedTransporter
-    // SMTP credentials come from a plain env var, matching the existing
+    // SMTP credentials come from plain env vars, matching the existing
     // pattern used by CAP_SECRET, SERVICE_API_KEY, etc. (see functions/.env
-    // and the captchaVerify helper). Set the value locally via
+    // and the captchaVerify helper). Set the values locally via
     // functions/.env and on Cloud Functions via deploy-time env vars or
     // --set-env-vars.
-    const uri = process.env.MAILGUN_SMTP_URI
-    if (!uri) {
-        throw new Error('MAILGUN_SMTP_URI env var is not configured')
+    //
+    // We take each SMTP component as its own variable rather than a single
+    // composed URI so neither the user nor the password ever needs URL
+    // encoding (`@` in the Mailgun username was a recurring foot-gun on
+    // the previous single-URI shape).
+    const host = process.env.MAILGUN_SMTP_HOST
+    const user = process.env.MAILGUN_SMTP_USER
+    const password = process.env.MAILGUN_SMTP_PASSWORD
+    if (!host || !user || !password) {
+        throw new Error(
+            'Mailgun SMTP env vars are not configured (need MAILGUN_SMTP_HOST, MAILGUN_SMTP_USER, MAILGUN_SMTP_PASSWORD)'
+        )
     }
-    // nodemailer accepts the SMTP URI directly as createTransport's first
-    // arg at runtime (see nodemailer docs), but its TS types do not
-    // expose that overload — hence the cast. The URI's scheme
-    // (`smtps://` vs `smtp://`) controls TLS mode; pool: true keeps the
-    // connection alive across messages within the same warm container.
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    cachedTransporter = (nodemailer.createTransport as any)(uri, {
+    // Port defaults to 465 (implicit TLS) — the most common Mailgun setup.
+    // 587 + STARTTLS is also supported by passing MAILGUN_SMTP_PORT=587.
+    const port = Number(process.env.MAILGUN_SMTP_PORT || 465)
+    // `secure: true` = implicit TLS from byte zero (port 465). For 587 we
+    // want STARTTLS, which nodemailer negotiates when `secure: false`.
+    const secure = port === 465
+    cachedTransporter = nodemailer.createTransport({
+        host,
+        port,
+        secure,
+        auth: { user, pass: password },
         pool: true,
         maxConnections: 3,
         maxMessages: 50,
-    }) as Transporter
+    })
     return cachedTransporter
 }
 

--- a/functions/src/api/other/sendEmail.ts
+++ b/functions/src/api/other/sendEmail.ts
@@ -45,14 +45,30 @@ const getTransporter = (): Transporter => {
     }
     // Port defaults to 465 (implicit TLS) — the most common Mailgun setup.
     // 587 + STARTTLS is also supported by passing MAILGUN_SMTP_PORT=587.
-    const port = Number(process.env.MAILGUN_SMTP_PORT || 465)
+    // Validate explicitly so a malformed env var (empty string, alphabetic,
+    // out-of-range) fails fast with a clear configuration error instead of
+    // hitting nodemailer with `0` / `NaN` and getting a cryptic socket
+    // error at first send.
+    const rawPort = process.env.MAILGUN_SMTP_PORT
+    let port = 465
+    if (rawPort !== undefined && rawPort !== '') {
+        const parsed = Number(rawPort)
+        if (!Number.isInteger(parsed) || parsed < 1 || parsed > 65535) {
+            throw new Error(`MAILGUN_SMTP_PORT must be an integer between 1 and 65535 (got "${rawPort}")`)
+        }
+        port = parsed
+    }
     // `secure: true` = implicit TLS from byte zero (port 465). For 587 we
     // want STARTTLS, which nodemailer negotiates when `secure: false`.
+    // `requireTLS: true` makes that negotiation mandatory — without it,
+    // nodemailer would happily fall back to plaintext if the server fails
+    // to advertise STARTTLS, leaking the SMTP credentials.
     const secure = port === 465
     cachedTransporter = nodemailer.createTransport({
         host,
         port,
         secure,
+        requireTLS: !secure,
         auth: { user, pass: password },
         pool: true,
         maxConnections: 3,

--- a/functions/src/api/routes/speakers/speakerSelfEdit.test.ts
+++ b/functions/src/api/routes/speakers/speakerSelfEdit.test.ts
@@ -256,8 +256,15 @@ describe('Speaker self-edit endpoints', () => {
     // Capture the original env values so the suite-level set + restore
     // never leaks credentials between suites when vitest runs files in
     // parallel. Snapshot once, restore in afterAll.
-    const ORIGINAL_SMTP_URI = process.env.MAILGUN_SMTP_URI
-    const ORIGINAL_MAIL_FROM = process.env.MAIL_FROM
+    const SMTP_KEYS = [
+        'MAILGUN_SMTP_HOST',
+        'MAILGUN_SMTP_PORT',
+        'MAILGUN_SMTP_USER',
+        'MAILGUN_SMTP_PASSWORD',
+        'MAIL_FROM',
+    ] as const
+    const ORIGINAL_ENV: Record<string, string | undefined> = {}
+    for (const k of SMTP_KEYS) ORIGINAL_ENV[k] = process.env[k]
 
     beforeAll(async () => {
         await fastify.ready()
@@ -265,7 +272,10 @@ describe('Speaker self-edit endpoints', () => {
         // so the values themselves do not need to be real credentials,
         // they just need to be present so sendEmail does not early-return
         // with a configuration error.
-        process.env.MAILGUN_SMTP_URI = 'smtps://test:test@localhost:465'
+        process.env.MAILGUN_SMTP_HOST = 'smtp.test.local'
+        process.env.MAILGUN_SMTP_PORT = '465'
+        process.env.MAILGUN_SMTP_USER = 'postmaster@test.local'
+        process.env.MAILGUN_SMTP_PASSWORD = 'test-secret'
         process.env.MAIL_FROM = 'OpenPlanner Test <noreply@test.local>'
     })
 
@@ -273,10 +283,10 @@ describe('Speaker self-edit endpoints', () => {
         // Restore the previous values (or delete if they were unset) so the
         // suite does not contaminate concurrent test files that exercise the
         // missing-env-var branches of sendEmail.
-        if (ORIGINAL_SMTP_URI === undefined) delete process.env.MAILGUN_SMTP_URI
-        else process.env.MAILGUN_SMTP_URI = ORIGINAL_SMTP_URI
-        if (ORIGINAL_MAIL_FROM === undefined) delete process.env.MAIL_FROM
-        else process.env.MAIL_FROM = ORIGINAL_MAIL_FROM
+        for (const k of SMTP_KEYS) {
+            if (ORIGINAL_ENV[k] === undefined) delete process.env[k]
+            else process.env[k] = ORIGINAL_ENV[k]
+        }
     })
 
     afterEach(() => {


### PR DESCRIPTION
## Summary

Follow-up to #254. The single `MAILGUN_SMTP_URI` we shipped trips on the `@` in the Mailgun username — it has to be URL-encoded as `%40` or the URL parser splits the user/host pair wrong. Replace it with one env var per component so neither user nor password ever needs encoding.

## Changes

- `functions/src/api/other/sendEmail.ts`: `getTransporter()` reads `MAILGUN_SMTP_HOST`, `MAILGUN_SMTP_PORT` (default 465), `MAILGUN_SMTP_USER`, `MAILGUN_SMTP_PASSWORD` and passes them to `nodemailer.createTransport` as discrete options. Drops the previous `(createTransport as any)(uri, opts)` cast — the structured-options overload is what nodemailer types expose, so the code is now cast-free. `secure: true` for port 465 (implicit TLS), `secure: false` for 587 (STARTTLS).
- `functions/.env.example`: replaced `MAILGUN_SMTP_URI` with the four new variables and a worked Mailgun example.
- `functions/src/api/other/sendEmail.test.ts`: env setup uses the four new keys; missing-URI test became missing-HOST test; added two new tests asserting (1) the transport options shape (host/port/secure/auth/pool) and (2) port 587 flips secure to false.
- `functions/src/api/routes/speakers/speakerSelfEdit.test.ts`: snapshot + restore generalised to the new five-key SMTP env set.

## Deploy migration

Replace the old single env var with the four new ones on the `api` function before the next deploy:

```bash
firebase deploy --only functions:api \
  --set-env-vars \
MAILGUN_SMTP_HOST=smtp.eu.mailgun.org,\
MAILGUN_SMTP_PORT=465,\
MAILGUN_SMTP_USER=postmaster@mg.yourdomain.com,\
MAILGUN_SMTP_PASSWORD=YOUR_SMTP_PASSWORD,\
MAIL_FROM="OpenPlanner <noreply@mg.yourdomain.com>"
```

Or set them in the Firebase Console (Functions → Configuration → Environment variables). The previous `MAILGUN_SMTP_URI` is no longer read and can be deleted from the function's environment after this deploy.

## Test plan

- [x] 212/212 backend tests pass (`vitest run` in `functions/`).
- [x] Backend tsc clean.
- [ ] Manual: trigger a request-edit-link from staging, observe `mail/` row transition PENDING → SUCCESS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
