### PR TITLE
Drop SaaS-setup mentions from speaker self-edit settings copy

### DIFF
--- a/src/events/page/speakers/components/SpeakerSelfEditSettings.tsx
+++ b/src/events/page/speakers/components/SpeakerSelfEditSettings.tsx
@@ -98,8 +98,7 @@ export const SpeakerSelfEditSettings = ({ event }: SpeakerSelfEditSettingsProps)
             <AccordionDetails>
                 <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
                     Speakers can request a magic link to edit their own profile. Each edit must be approved by an admin
-                    before being applied. Max 5 emails per speaker per day. Requires the captcha service
-                    (captcha.openplanner.fr) and the Firebase "Trigger Email" extension installed.
+                    before being applied. Max 5 emails per speaker per day.
                 </Typography>
 
                 <FormControlLabel


### PR DESCRIPTION
## Summary

The admin-facing speaker self-edit settings panel was leaking deployment-specific plumbing into the in-app description ("Requires the captcha service (captcha.openplanner.fr) and the Firebase 'Trigger Email' extension installed."). Self-edit is now backed by direct SMTP anyway, so the Trigger Email reference is also stale.

Trim to the user-facing functional description (magic link, admin approval, 5 emails/speaker/day rate limit). Infrastructure concerns belong in deploy docs.

## Before / after

Before:
> Speakers can request a magic link to edit their own profile. Each edit must be approved by an admin before being applied. Max 5 emails per speaker per day. Requires the captcha service (captcha.openplanner.fr) and the Firebase "Trigger Email" extension installed.

After:
> Speakers can request a magic link to edit their own profile. Each edit must be approved by an admin before being applied. Max 5 emails per speaker per day.

## Test plan

- [x] Frontend tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
