### PR TITLE
Make Cap captcha endpoint configurable via VITE_CAP_API_ENDPOINT

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,10 +11,5 @@ VITE_FIREBASE_OPEN_PLANNER_API_URL=https://example.com
 VITE_FIREBASE_OPEN_PLANNER_FUNCTION_URL=http://127.0.0.1:5001/conferencecenterr/europe-west1/api/
 VITE_OPEN_SPONSORS_URL=https://example.com
 # Cap captcha service BASE URL used by the public speaker self-edit form.
-# Passed as `data-cap-api-endpoint` to the <cap-widget>, so do NOT include
-# the `/siteverify` suffix — the widget appends its own paths. The
-# functions-side CAP_VERIFY_URL is a different variable: it is the full
-# verification endpoint, typically this base URL + `/siteverify`. Both
-# must point at the same Cap instance (same host). Defaults to
-# https://captcha.openplanner.fr/ when unset.
-VITE_CAP_API_ENDPOINT=https://captcha.openplanner.fr/
+# Passed as `data-cap-api-endpoint` to the <cap-widget>, so do include the site key at the end.
+VITE_CAP_API_ENDPOINT=https://example.com/xxxxx/

--- a/.env.example
+++ b/.env.example
@@ -10,7 +10,11 @@ VITE_FIREBASE_OPEN_PLANNER_API_URL=https://example.com
 # Example: https://europe-west1-<project>.cloudfunctions.net/api
 VITE_FIREBASE_OPEN_PLANNER_FUNCTION_URL=http://127.0.0.1:5001/conferencecenterr/europe-west1/api/
 VITE_OPEN_SPONSORS_URL=https://example.com
-# Cap captcha service endpoint used by the public speaker self-edit form.
-# Must match the CAP_VERIFY_URL on the functions side. Defaults to
+# Cap captcha service BASE URL used by the public speaker self-edit form.
+# Passed as `data-cap-api-endpoint` to the <cap-widget>, so do NOT include
+# the `/siteverify` suffix — the widget appends its own paths. The
+# functions-side CAP_VERIFY_URL is a different variable: it is the full
+# verification endpoint, typically this base URL + `/siteverify`. Both
+# must point at the same Cap instance (same host). Defaults to
 # https://captcha.openplanner.fr/ when unset.
 VITE_CAP_API_ENDPOINT=https://captcha.openplanner.fr/

--- a/.env.example
+++ b/.env.example
@@ -10,3 +10,7 @@ VITE_FIREBASE_OPEN_PLANNER_API_URL=https://example.com
 # Example: https://europe-west1-<project>.cloudfunctions.net/api
 VITE_FIREBASE_OPEN_PLANNER_FUNCTION_URL=http://127.0.0.1:5001/conferencecenterr/europe-west1/api/
 VITE_OPEN_SPONSORS_URL=https://example.com
+# Cap captcha service endpoint used by the public speaker self-edit form.
+# Must match the CAP_VERIFY_URL on the functions side. Defaults to
+# https://captcha.openplanner.fr/ when unset.
+VITE_CAP_API_ENDPOINT=https://captcha.openplanner.fr/

--- a/functions/.env.example
+++ b/functions/.env.example
@@ -2,7 +2,7 @@ BUCKET=aaaaa.appspot.com
 SERVICE_API_KEY=xxxx
 G_FIREBASE_PROJECT_ID=xxx
 CAP_SECRET=xxx
-CAP_VERIFY_URL=xxx
+CAP_VERIFY_URL=xxx/sitekey/siteverify
 PUBLIC_APP_URL=https://openplanner.fr
 
 # Mailgun SMTP connection URI used by the speaker self-edit email flow.

--- a/src/env.ts
+++ b/src/env.ts
@@ -5,3 +5,8 @@ export const API_URL = import.meta.env.VITE_FIREBASE_OPEN_PLANNER_API_URL
 export const FUNCTION_API_URL =
     import.meta.env.VITE_FIREBASE_OPEN_PLANNER_FUNCTION_URL || import.meta.env.VITE_FIREBASE_OPEN_PLANNER_API_URL
 export const OpenSponsorsUrl = import.meta.env.VITE_OPEN_SPONSORS_URL
+// Endpoint of the self-hosted Cap captcha service used by the public
+// speaker self-edit flow. Configurable so each deploy can point at its
+// own Cap instance; falls back to the openplanner.fr hosted one for
+// backwards compatibility with existing installs.
+export const CAP_API_ENDPOINT = import.meta.env.VITE_CAP_API_ENDPOINT || 'https://captcha.openplanner.fr/'

--- a/src/public/speakerEdit/CapWidget.tsx
+++ b/src/public/speakerEdit/CapWidget.tsx
@@ -6,6 +6,7 @@ import { useEffect, useRef } from 'react'
 // is served from our own deploy instead of a third-party CDN — closes
 // the supply-chain vector that the previous jsdelivr <script> opened.
 import '@cap.js/widget'
+import { CAP_API_ENDPOINT } from '../../env'
 
 declare global {
     namespace JSX {
@@ -17,8 +18,6 @@ declare global {
         }
     }
 }
-
-const CAP_API_ENDPOINT = 'https://captcha.openplanner.fr/'
 
 export type CapWidgetProps = {
     onSolve: (token: string) => void


### PR DESCRIPTION
## Summary

The public speaker self-edit widget was hard-coded to `https://captcha.openplanner.fr/` — fine for the openplanner.fr install but blocks any other deployment from pointing at its own Cap instance.

## Changes

- `src/env.ts`: new export `CAP_API_ENDPOINT`, reads `import.meta.env.VITE_CAP_API_ENDPOINT` with a fallback to the existing openplanner.fr URL so existing deployments keep working without a config change.
- `src/public/speakerEdit/CapWidget.tsx`: imports the value instead of inlining the literal. `data-cap-api-endpoint` attribute unchanged.
- `.env.example`: documented next to the other `VITE_*` entries. Note added that it should match `CAP_VERIFY_URL` on the functions side so verify hits the same Cap instance.

## Test plan

- [x] Frontend tsc clean; vite build succeeds.
- [ ] Manual: set `VITE_CAP_API_ENDPOINT=https://your-cap.example/` in `.env.local`, reload the speaker-edit request page, inspect the rendered `<cap-widget>` — the attribute should match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
