### PR TITLE
feat: include tickets node in public static JSON

### DIFF
--- a/functions/src/api/dao/ticketDao.ts
+++ b/functions/src/api/dao/ticketDao.ts
@@ -12,8 +12,8 @@ export interface TicketData {
     soldOut: boolean
     highlighted: boolean
     displayNewsletterRegistration: boolean
-    startDate: Timestamp | null
-    endDate: Timestamp | null
+    startDate: Timestamp | string | null
+    endDate: Timestamp | string | null
     message: string
 }
 

--- a/functions/src/api/dao/ticketDao.ts
+++ b/functions/src/api/dao/ticketDao.ts
@@ -1,0 +1,29 @@
+import firebase from 'firebase-admin'
+import { Timestamp } from 'firebase-admin/firestore'
+
+export interface TicketData {
+    id: string
+    name: string
+    price: number
+    currency: string
+    url: string
+    ticketsCount: number
+    available: boolean
+    soldOut: boolean
+    highlighted: boolean
+    displayNewsletterRegistration: boolean
+    startDate: Timestamp | null
+    endDate: Timestamp | null
+    message: string
+}
+
+export class TicketDao {
+    public static async getTickets(firebaseApp: firebase.app.App, eventId: string): Promise<TicketData[]> {
+        const db = firebaseApp.firestore()
+        const snapshot = await db.collection(`events/${eventId}/tickets`).get()
+        return snapshot.docs.map((doc) => ({
+            ...(doc.data() as TicketData),
+            id: doc.id,
+        }))
+    }
+}

--- a/functions/src/api/routes/deploy/updateWebsiteActions/generateStaticJson.test.ts
+++ b/functions/src/api/routes/deploy/updateWebsiteActions/generateStaticJson.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, test, vi, beforeEach } from 'vitest'
+import { generateStaticJson } from './generateStaticJson'
+import { SessionDao } from '../../../dao/sessionDao'
+import { SpeakerDao } from '../../../dao/speakerDao'
+import { SponsorDao } from '../../../dao/sponsorDao'
+import { TeamDao } from '../../../dao/teamDao'
+import { FaqDao } from '../../../dao/faqDao'
+import { JobPostDao } from '../../../dao/jobPostDao'
+import { TicketDao } from '../../../dao/ticketDao'
+import { Event } from '../../../../types'
+
+const event = {
+    id: 'evt-1',
+    name: 'Test Event',
+    scheduleVisible: true,
+    dates: { start: new Date('2026-01-01T09:00:00Z'), end: new Date('2026-01-02T18:00:00Z') },
+    formats: [],
+    categories: [],
+    tracks: [],
+    updatedAt: new Date('2026-01-01T00:00:00Z'),
+    timezone: 'Europe/Paris',
+    enableVoxxrin: false,
+} as unknown as Event
+
+const firebaseApp = {} as any
+
+beforeEach(() => {
+    vi.spyOn(SessionDao, 'getSessions').mockResolvedValue([])
+    vi.spyOn(SpeakerDao, 'getSpeakers').mockResolvedValue([])
+    vi.spyOn(SponsorDao, 'getSponsors').mockResolvedValue([])
+    vi.spyOn(TeamDao, 'getTeams').mockResolvedValue({ team: [], teams: [] })
+    vi.spyOn(FaqDao, 'getFullFaqs').mockResolvedValue([])
+    vi.spyOn(JobPostDao, 'getAllJobPosts').mockResolvedValue([])
+})
+
+describe('generateStaticJson tickets node', () => {
+    test('includes tickets in both public and private outputs', async () => {
+        vi.spyOn(TicketDao, 'getTickets').mockResolvedValue([
+            {
+                id: 't1',
+                name: 'Early Bird',
+                price: 100,
+                currency: 'EUR',
+                url: 'https://example.com/t1',
+                ticketsCount: 50,
+                available: true,
+                soldOut: false,
+                highlighted: true,
+                displayNewsletterRegistration: false,
+                startDate: '2026-01-01T00:00:00.000+00:00',
+                endDate: null,
+                message: '',
+            },
+        ])
+
+        const { outputPublic, outputPrivate } = await generateStaticJson(firebaseApp, event)
+
+        expect(outputPublic.tickets).toHaveLength(1)
+        expect(outputPrivate.tickets).toHaveLength(1)
+        const ticket = outputPublic.tickets[0]
+        expect(ticket.id).toBe('t1')
+        expect(ticket.currency).toBe('EUR')
+        expect(typeof ticket.startDate).toBe('string')
+        expect(ticket.endDate).toBeNull()
+    })
+
+    test('normalizes Firestore Timestamp dates to ISO strings', async () => {
+        vi.spyOn(TicketDao, 'getTickets').mockResolvedValue([
+            {
+                id: 't2',
+                name: 'Regular',
+                price: 200,
+                currency: 'USD',
+                url: 'https://example.com/t2',
+                ticketsCount: 100,
+                available: true,
+                soldOut: false,
+                highlighted: false,
+                displayNewsletterRegistration: false,
+                startDate: { toDate: () => new Date('2026-02-01T10:00:00Z') } as any,
+                endDate: { toDate: () => new Date('2026-02-10T10:00:00Z') } as any,
+                message: '',
+            },
+        ])
+
+        const { outputPublic } = await generateStaticJson(firebaseApp, event)
+        const ticket = outputPublic.tickets[0]
+        expect(ticket.startDate).toContain('2026-02-01')
+        expect(ticket.endDate).toContain('2026-02-10')
+    })
+
+    test('emits an empty tickets array when there are no tickets', async () => {
+        vi.spyOn(TicketDao, 'getTickets').mockResolvedValue([])
+
+        const { outputPublic, outputPrivate } = await generateStaticJson(firebaseApp, event)
+        expect(outputPublic.tickets).toEqual([])
+        expect(outputPrivate.tickets).toEqual([])
+    })
+})

--- a/functions/src/api/routes/deploy/updateWebsiteActions/generateStaticJson.ts
+++ b/functions/src/api/routes/deploy/updateWebsiteActions/generateStaticJson.ts
@@ -2,27 +2,52 @@ import firebase from 'firebase-admin'
 import { Event } from '../../../../../../src/types'
 import { generateOpenFeedbackJson } from './generateOpenFeedbackJson'
 import { generateVoxxrinJson } from './generateVoxxrinJson'
-import { JsonOutput, JsonSession, JsonSessionPrivate, JsonPublicOutput, JsonPrivateOutput } from './jsonTypes'
+import {
+    JsonOutput,
+    JsonSession,
+    JsonSessionPrivate,
+    JsonPublicOutput,
+    JsonPrivateOutput,
+    JsonTicket,
+} from './jsonTypes'
 import { SessionDao } from '../../../dao/sessionDao'
 import { SpeakerDao } from '../../../dao/speakerDao'
 import { SponsorDao } from '../../../dao/sponsorDao'
 import { TeamDao } from '../../../dao/teamDao'
 import { FaqDao } from '../../../dao/faqDao'
 import { JobPostDao } from '../../../dao/jobPostDao'
+import { TicketDao } from '../../../dao/ticketDao'
 import { JobStatus } from '../../../../../../src/constants/jobStatus'
-import { dateToString } from '../../../other/dateConverter'
+import { dateToString, unknownToDateTime } from '../../../other/dateConverter'
 
 export const generateStaticJson = async (firebaseApp: firebase.app.App, event: Event): Promise<JsonOutput> => {
-    const [sessions, speakers, sponsors, { team, teams }, faq, jobPosts] = await Promise.all([
+    const [sessions, speakers, sponsors, { team, teams }, faq, jobPosts, tickets] = await Promise.all([
         SessionDao.getSessions(firebaseApp, event.id),
         SpeakerDao.getSpeakers(firebaseApp, event.id),
         SponsorDao.getSponsors(firebaseApp, event.id),
         TeamDao.getTeams(firebaseApp, event.id),
         FaqDao.getFullFaqs(firebaseApp, event.id),
         JobPostDao.getAllJobPosts(firebaseApp, event.id, JobStatus.APPROVED),
+        TicketDao.getTickets(firebaseApp, event.id),
     ])
 
     const faqPublic = faq.filter((f) => !f.private)
+
+    const outputTickets: JsonTicket[] = tickets.map((t) => ({
+        id: t.id,
+        name: t.name,
+        price: t.price,
+        currency: t.currency,
+        url: t.url,
+        ticketsCount: t.ticketsCount,
+        available: t.available,
+        soldOut: t.soldOut,
+        highlighted: t.highlighted,
+        displayNewsletterRegistration: t.displayNewsletterRegistration,
+        startDate: t.startDate ? dateToString(unknownToDateTime(t.startDate as any)) : null,
+        endDate: t.endDate ? dateToString(unknownToDateTime(t.endDate as any)) : null,
+        message: t.message,
+    }))
 
     const openFeedbackOutput = generateOpenFeedbackJson(event, sessions, speakers)
     const voxxrinJson = event.enableVoxxrin ? generateVoxxrinJson(event, sessions, speakers, sponsors) : null
@@ -173,6 +198,7 @@ export const generateStaticJson = async (firebaseApp: firebase.app.App, event: E
         team,
         teams,
         faq: faqPublic,
+        tickets: outputTickets,
         timezone: event.timezone,
         generatedAt: dateToString(new Date()),
     }
@@ -184,6 +210,7 @@ export const generateStaticJson = async (firebaseApp: firebase.app.App, event: E
         team,
         teams,
         faq,
+        tickets: outputTickets,
         timezone: event.timezone,
         generatedAt: dateToString(new Date()),
     }

--- a/functions/src/api/routes/deploy/updateWebsiteActions/generateStaticJson.ts
+++ b/functions/src/api/routes/deploy/updateWebsiteActions/generateStaticJson.ts
@@ -1,5 +1,5 @@
 import firebase from 'firebase-admin'
-import { Event } from '../../../../../../src/types'
+import { Event, TicketCurrency } from '../../../../../../src/types'
 import { generateOpenFeedbackJson } from './generateOpenFeedbackJson'
 import { generateVoxxrinJson } from './generateVoxxrinJson'
 import {
@@ -37,15 +37,15 @@ export const generateStaticJson = async (firebaseApp: firebase.app.App, event: E
         id: t.id,
         name: t.name,
         price: t.price,
-        currency: t.currency,
+        currency: t.currency as TicketCurrency,
         url: t.url,
         ticketsCount: t.ticketsCount,
         available: t.available,
         soldOut: t.soldOut,
         highlighted: t.highlighted,
         displayNewsletterRegistration: t.displayNewsletterRegistration,
-        startDate: t.startDate ? dateToString(unknownToDateTime(t.startDate as any)) : null,
-        endDate: t.endDate ? dateToString(unknownToDateTime(t.endDate as any)) : null,
+        startDate: t.startDate ? unknownToDateTime(t.startDate as any).toISO() : null,
+        endDate: t.endDate ? unknownToDateTime(t.endDate as any).toISO() : null,
         message: t.message,
     }))
 

--- a/functions/src/api/routes/deploy/updateWebsiteActions/jsonTypes.ts
+++ b/functions/src/api/routes/deploy/updateWebsiteActions/jsonTypes.ts
@@ -52,6 +52,22 @@ export interface JsonSpeaker {
     customFields?: { [key: string]: string | boolean }
 }
 
+export interface JsonTicket {
+    id: string
+    name: string
+    price: number
+    currency: string
+    url: string
+    ticketsCount: number
+    available: boolean
+    soldOut: boolean
+    highlighted: boolean
+    displayNewsletterRegistration: boolean
+    startDate: string | null
+    endDate: string | null
+    message: string
+}
+
 export interface JsonEvent {
     id: string
     name: string
@@ -82,6 +98,7 @@ export interface JsonPublicOutput {
     team: TeamMember[]
     teams: { id: string; members: TeamMember[]; order: number }[]
     faq: FaqCategory[]
+    tickets: JsonTicket[]
     timezone: string | null | undefined
     generatedAt: string
 }

--- a/functions/src/api/routes/deploy/updateWebsiteActions/jsonTypes.ts
+++ b/functions/src/api/routes/deploy/updateWebsiteActions/jsonTypes.ts
@@ -8,6 +8,7 @@ import {
     Social,
     SponsorCustomField,
     SpeakerCustomField,
+    TicketCurrency,
 } from '../../../../../../src/types'
 
 export interface JsonSession {
@@ -56,7 +57,7 @@ export interface JsonTicket {
     id: string
     name: string
     price: number
-    currency: string
+    currency: TicketCurrency
     url: string
     ticketsCount: number
     available: boolean


### PR DESCRIPTION
## What

Adds a `tickets` node to the generated public **and** private static JSON for an event.

## Why

Tickets are stored in Firestore at `events/{eventId}/tickets`, but `generateStaticJson` never fetched or emitted them — so deployed event sites had no access to ticket data. This fills that missing node.

## Changes

- **New** `functions/src/api/dao/ticketDao.ts` — `TicketDao.getTickets()` reads the `tickets` subcollection.
- `jsonTypes.ts` — new `JsonTicket` interface; `tickets: JsonTicket[]` added to `JsonPublicOutput` (private output inherits it).
- `generateStaticJson.ts` — fetch tickets in the `Promise.all`, map to `outputTickets`, include in both public and private outputs.

## Notes for reviewer

- Ticket `startDate`/`endDate` are normalized to ISO strings via `unknownToDateTime` + `dateToString`, handling both Firestore `Timestamp` and ISO-string storage (frontend converter allows both).
- Tickets are included in the **private** JSON too — flag if it should be public-only.
- `tsc --noEmit` passes on `functions/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)