### PR TITLE
Add fullscreen button to the intermission screen

### DIFF
--- a/src/public/intermission/IntermissionScreen.tsx
+++ b/src/public/intermission/IntermissionScreen.tsx
@@ -89,6 +89,21 @@ export const IntermissionScreen = ({
         return () => clearInterval(id)
     }, [intermittent, intervalSec])
 
+    // Fullscreen toggle — the intermission runs on a room screen, so let the operator go edge-to-edge
+    const [isFullscreen, setIsFullscreen] = useState(false)
+    useEffect(() => {
+        const onChange = () => setIsFullscreen(Boolean(document.fullscreenElement))
+        document.addEventListener('fullscreenchange', onChange)
+        return () => document.removeEventListener('fullscreenchange', onChange)
+    }, [])
+    const toggleFullscreen = () => {
+        if (document.fullscreenElement) {
+            document.exitFullscreen?.()
+        } else {
+            document.documentElement.requestFullscreen?.()
+        }
+    }
+
     // Hide the controls (and cursor) after a period of pointer inactivity; reveal on any movement
     const [idle, setIdle] = useState(false)
     const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
@@ -145,6 +160,37 @@ export const IntermissionScreen = ({
                     pointerEvents: idle && !settingsOpen ? 'none' : 'auto',
                     transition: 'opacity 0.4s ease',
                 }}>
+                <button
+                    style={styles.cog}
+                    aria-label={isFullscreen ? 'Exit fullscreen' : 'Enter fullscreen'}
+                    onClick={toggleFullscreen}>
+                    <svg
+                        width="22"
+                        height="22"
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        stroke="currentColor"
+                        strokeWidth="2"
+                        strokeLinecap="round"
+                        strokeLinejoin="round">
+                        {isFullscreen ? (
+                            <>
+                                <path d="M8 3v3a2 2 0 0 1-2 2H3" />
+                                <path d="M21 8h-3a2 2 0 0 1-2-2V3" />
+                                <path d="M3 16h3a2 2 0 0 1 2 2v3" />
+                                <path d="M16 21v-3a2 2 0 0 1 2-2h3" />
+                            </>
+                        ) : (
+                            <>
+                                <path d="M8 3H5a2 2 0 0 0-2 2v3" />
+                                <path d="M21 8V5a2 2 0 0 0-2-2h-3" />
+                                <path d="M3 16v3a2 2 0 0 0 2 2h3" />
+                                <path d="M16 21h3a2 2 0 0 0 2-2v-3" />
+                            </>
+                        )}
+                    </svg>
+                </button>
+
                 <button style={styles.cog} aria-label="Settings" onClick={() => setSettingsOpen((v) => !v)}>
                     <svg
                         width="22"


### PR DESCRIPTION
## What

Adds a **fullscreen toggle** to the intermission screen so a room/kiosk display can go edge-to-edge with one click.

- New button next to the settings cog in the top-right controls — fades out with the idle auto-hide like the rest of the controls.
- Uses the Fullscreen API: `requestFullscreen()` on the document element / `exitFullscreen()`.
- Listens to `fullscreenchange` and swaps the icon between **enter** and **exit** states, so it stays correct even when the user leaves fullscreen via `Esc`.

## Notes

- Builds on the intermission screen introduced in [#265](https://github.com/HugoGresse/OpenPlanner/pull/265) (now merged).
- Touches only `src/public/intermission/IntermissionScreen.tsx`. tsc clean.

## Test plan

- Open the intermission screen, click the fullscreen button → goes fullscreen, icon flips to "exit".
- Press `Esc` → leaves fullscreen, icon flips back to "enter".
- Move mouse away → controls (incl. button) fade; move → reappear.