### PR TITLE
WhatsApp track management (GreenAPI): setup + interactive ready/GO flow

### DIFF
--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -3609,9 +3609,6 @@
                 "arm"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3626,9 +3623,6 @@
                 "arm"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3643,9 +3637,6 @@
                 "arm64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3660,9 +3651,6 @@
                 "arm64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3677,9 +3665,6 @@
                 "ppc64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3694,9 +3679,6 @@
                 "riscv64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3711,9 +3693,6 @@
                 "s390x"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3728,9 +3707,6 @@
                 "x64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3745,9 +3721,6 @@
                 "x64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -11997,6 +11970,25 @@
                 "node": ">= 14"
             }
         },
+        "node_modules/proxy-agent-negotiate": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/proxy-agent-negotiate/-/proxy-agent-negotiate-1.1.0.tgz",
+            "integrity": "sha512-N8IBcM3UgCVzz2L2Lqv8DVntDnnC8/hiV4nEDUPkqq72TPUgYWjQc+bdZlBPZK9LzPAvOY//gAt0S0DApoOXWQ==",
+            "license": "MIT",
+            "optional": true,
+            "peer": true,
+            "engines": {
+                "node": ">= 20"
+            },
+            "peerDependencies": {
+                "kerberos": "^2.0.0"
+            },
+            "peerDependenciesMeta": {
+                "kerberos": {
+                    "optional": true
+                }
+            }
+        },
         "node_modules/proxy-agent/node_modules/agent-base": {
             "version": "7.1.3",
             "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.3.tgz",
@@ -12162,6 +12154,17 @@
                 }
             }
         },
+        "node_modules/puppeteer-core/node_modules/agent-base": {
+            "version": "9.0.0",
+            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-9.0.0.tgz",
+            "integrity": "sha512-TQf59BsZnytt8GdJKLPfUZ54g/iaUL2OWDSFCCvMOhsHduDQxO8xC4PNeyIkVcA5KwL2phPSv0douC0fgWzmnA==",
+            "license": "MIT",
+            "optional": true,
+            "peer": true,
+            "engines": {
+                "node": ">= 20"
+            }
+        },
         "node_modules/puppeteer-core/node_modules/ansi-regex": {
             "version": "6.2.2",
             "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
@@ -12200,11 +12203,221 @@
                 "node": ">=20"
             }
         },
+        "node_modules/puppeteer-core/node_modules/data-uri-to-buffer": {
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-8.0.0.tgz",
+            "integrity": "sha512-6UHfyCux51b8PTGDgveqtz1tvphBku5DrMKKJbFAZAJOI2zsjDpDoYE1+QGj7FOMS4BdTFNJsJiR3zEB0xH0yQ==",
+            "license": "MIT",
+            "optional": true,
+            "peer": true,
+            "engines": {
+                "node": ">= 20"
+            }
+        },
+        "node_modules/puppeteer-core/node_modules/degenerator": {
+            "version": "7.0.1",
+            "resolved": "https://registry.npmjs.org/degenerator/-/degenerator-7.0.1.tgz",
+            "integrity": "sha512-ABErK0IefDSyHjlPH7WUEenIAX2rPPnrDcDM+TS3z3+zu9TfyKKi07BQM+8rmxpdE2y1v5fjjdoAS/x4D2U60w==",
+            "license": "MIT",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "ast-types": "^0.13.4",
+                "escodegen": "^2.1.0",
+                "esprima": "^4.0.1"
+            },
+            "engines": {
+                "node": ">= 20"
+            },
+            "peerDependencies": {
+                "quickjs-wasi": "^2.2.0"
+            }
+        },
         "node_modules/puppeteer-core/node_modules/emoji-regex": {
             "version": "10.6.0",
             "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
             "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
             "license": "MIT"
+        },
+        "node_modules/puppeteer-core/node_modules/escodegen": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.1.0.tgz",
+            "integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
+            "license": "BSD-2-Clause",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "esprima": "^4.0.1",
+                "estraverse": "^5.2.0",
+                "esutils": "^2.0.2"
+            },
+            "bin": {
+                "escodegen": "bin/escodegen.js",
+                "esgenerate": "bin/esgenerate.js"
+            },
+            "engines": {
+                "node": ">=6.0"
+            },
+            "optionalDependencies": {
+                "source-map": "~0.6.1"
+            }
+        },
+        "node_modules/puppeteer-core/node_modules/estraverse": {
+            "version": "5.3.0",
+            "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+            "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+            "license": "BSD-2-Clause",
+            "optional": true,
+            "peer": true,
+            "engines": {
+                "node": ">=4.0"
+            }
+        },
+        "node_modules/puppeteer-core/node_modules/get-uri": {
+            "version": "8.0.1",
+            "resolved": "https://registry.npmjs.org/get-uri/-/get-uri-8.0.1.tgz",
+            "integrity": "sha512-/5N/P4Lrh0p/mDwlDRi7Y1+P2o/OyzZI3l6Iz1Ov6XXwwm1y3RlZLuo3gVgML99djrEDtV980bBxSuOeHLk8ww==",
+            "license": "MIT",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "basic-ftp": "^5.3.1",
+                "data-uri-to-buffer": "8.0.0",
+                "debug": "^4.3.4"
+            },
+            "engines": {
+                "node": ">= 20"
+            }
+        },
+        "node_modules/puppeteer-core/node_modules/http-proxy-agent": {
+            "version": "9.1.0",
+            "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-9.1.0.tgz",
+            "integrity": "sha512-2NxoveTT58mjYT4n3RPTEfCZGLMbidoO8XEieXfpSYxu+PQJ1qpx4ypwH6N+uF9twBPIvRRgvkvW5HUTYWENig==",
+            "license": "MIT",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "agent-base": "9.0.0",
+                "debug": "^4.3.4",
+                "proxy-agent-negotiate": "1.1.0"
+            },
+            "engines": {
+                "node": ">= 20"
+            }
+        },
+        "node_modules/puppeteer-core/node_modules/https-proxy-agent": {
+            "version": "9.1.0",
+            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-9.1.0.tgz",
+            "integrity": "sha512-ag87y7cJJ9/3+GxFr8Oy4O5faDsGRGnBGsJj/YjOSsSx/5eadKLYTMPlzuR6obgoCDDm0abAAZitXXQkMOPSpA==",
+            "license": "MIT",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "agent-base": "9.0.0",
+                "debug": "^4.3.4",
+                "proxy-agent-negotiate": "1.1.0"
+            },
+            "engines": {
+                "node": ">= 20"
+            }
+        },
+        "node_modules/puppeteer-core/node_modules/lru-cache": {
+            "version": "7.18.3",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
+            "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
+            "license": "ISC",
+            "optional": true,
+            "peer": true,
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/puppeteer-core/node_modules/pac-proxy-agent": {
+            "version": "9.1.0",
+            "resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-9.1.0.tgz",
+            "integrity": "sha512-1aU+1mpj3DrQPfo3gh+3Gap3G5x+axnMx1P/y0ZF2ch7kb2meyOCAH8K2k9d27ROsTE7TnAerzxqF9aon2jqnA==",
+            "license": "MIT",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "agent-base": "9.0.0",
+                "debug": "^4.3.4",
+                "get-uri": "8.0.1",
+                "http-proxy-agent": "9.1.0",
+                "https-proxy-agent": "9.1.0",
+                "pac-resolver": "9.0.1",
+                "quickjs-wasi": "^2.2.0",
+                "socks-proxy-agent": "10.1.0"
+            },
+            "engines": {
+                "node": ">= 20"
+            }
+        },
+        "node_modules/puppeteer-core/node_modules/pac-resolver": {
+            "version": "9.0.1",
+            "resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-9.0.1.tgz",
+            "integrity": "sha512-lJbS008tmkj08VhoM8Hzuv/VE5tK9MS0OIQ/7+s0lIF+BYhiQWFYzkSpML7lXs9iBu2jfmzBTLzhe9n6BX+dYw==",
+            "license": "MIT",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "degenerator": "7.0.1",
+                "netmask": "^2.0.2"
+            },
+            "engines": {
+                "node": ">= 20"
+            },
+            "peerDependencies": {
+                "quickjs-wasi": "^2.2.0"
+            }
+        },
+        "node_modules/puppeteer-core/node_modules/proxy-agent": {
+            "version": "8.0.2",
+            "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-8.0.2.tgz",
+            "integrity": "sha512-idLLRewuemWd7GH/BDJzGiB0dWGfT2SQs3jy6NtZtGWU9uPTTSdeC1/cdbqLwgzhfv027daGFuXX426e2Eg20A==",
+            "license": "MIT",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "agent-base": "9.0.0",
+                "debug": "^4.3.4",
+                "http-proxy-agent": "9.1.0",
+                "https-proxy-agent": "9.1.0",
+                "lru-cache": "^7.14.1",
+                "pac-proxy-agent": "9.1.0",
+                "proxy-from-env": "^2.0.0",
+                "socks-proxy-agent": "10.1.0"
+            },
+            "engines": {
+                "node": ">= 20"
+            }
+        },
+        "node_modules/puppeteer-core/node_modules/proxy-from-env": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+            "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+            "license": "MIT",
+            "optional": true,
+            "peer": true,
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/puppeteer-core/node_modules/socks-proxy-agent": {
+            "version": "10.1.0",
+            "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-10.1.0.tgz",
+            "integrity": "sha512-WlMj/67cEJ6MDI1OcsnjuYKDNDoyPCCYZ249kuuXPiMDw9F8PXkVaQ7YWu3siTydfQ/4BEZcvGzu+aYvz7dDCQ==",
+            "license": "MIT",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "agent-base": "9.0.0",
+                "debug": "^4.3.4",
+                "socks": "^2.8.3"
+            },
+            "engines": {
+                "node": ">= 20"
+            }
         },
         "node_modules/puppeteer-core/node_modules/string-width": {
             "version": "7.2.0",
@@ -12305,6 +12518,17 @@
                 }
             }
         },
+        "node_modules/puppeteer/node_modules/agent-base": {
+            "version": "9.0.0",
+            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-9.0.0.tgz",
+            "integrity": "sha512-TQf59BsZnytt8GdJKLPfUZ54g/iaUL2OWDSFCCvMOhsHduDQxO8xC4PNeyIkVcA5KwL2phPSv0douC0fgWzmnA==",
+            "license": "MIT",
+            "optional": true,
+            "peer": true,
+            "engines": {
+                "node": ">= 20"
+            }
+        },
         "node_modules/puppeteer/node_modules/ansi-regex": {
             "version": "6.2.2",
             "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
@@ -12343,11 +12567,221 @@
                 "node": ">=20"
             }
         },
+        "node_modules/puppeteer/node_modules/data-uri-to-buffer": {
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-8.0.0.tgz",
+            "integrity": "sha512-6UHfyCux51b8PTGDgveqtz1tvphBku5DrMKKJbFAZAJOI2zsjDpDoYE1+QGj7FOMS4BdTFNJsJiR3zEB0xH0yQ==",
+            "license": "MIT",
+            "optional": true,
+            "peer": true,
+            "engines": {
+                "node": ">= 20"
+            }
+        },
+        "node_modules/puppeteer/node_modules/degenerator": {
+            "version": "7.0.1",
+            "resolved": "https://registry.npmjs.org/degenerator/-/degenerator-7.0.1.tgz",
+            "integrity": "sha512-ABErK0IefDSyHjlPH7WUEenIAX2rPPnrDcDM+TS3z3+zu9TfyKKi07BQM+8rmxpdE2y1v5fjjdoAS/x4D2U60w==",
+            "license": "MIT",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "ast-types": "^0.13.4",
+                "escodegen": "^2.1.0",
+                "esprima": "^4.0.1"
+            },
+            "engines": {
+                "node": ">= 20"
+            },
+            "peerDependencies": {
+                "quickjs-wasi": "^2.2.0"
+            }
+        },
         "node_modules/puppeteer/node_modules/emoji-regex": {
             "version": "10.6.0",
             "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
             "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
             "license": "MIT"
+        },
+        "node_modules/puppeteer/node_modules/escodegen": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.1.0.tgz",
+            "integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
+            "license": "BSD-2-Clause",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "esprima": "^4.0.1",
+                "estraverse": "^5.2.0",
+                "esutils": "^2.0.2"
+            },
+            "bin": {
+                "escodegen": "bin/escodegen.js",
+                "esgenerate": "bin/esgenerate.js"
+            },
+            "engines": {
+                "node": ">=6.0"
+            },
+            "optionalDependencies": {
+                "source-map": "~0.6.1"
+            }
+        },
+        "node_modules/puppeteer/node_modules/estraverse": {
+            "version": "5.3.0",
+            "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+            "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+            "license": "BSD-2-Clause",
+            "optional": true,
+            "peer": true,
+            "engines": {
+                "node": ">=4.0"
+            }
+        },
+        "node_modules/puppeteer/node_modules/get-uri": {
+            "version": "8.0.1",
+            "resolved": "https://registry.npmjs.org/get-uri/-/get-uri-8.0.1.tgz",
+            "integrity": "sha512-/5N/P4Lrh0p/mDwlDRi7Y1+P2o/OyzZI3l6Iz1Ov6XXwwm1y3RlZLuo3gVgML99djrEDtV980bBxSuOeHLk8ww==",
+            "license": "MIT",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "basic-ftp": "^5.3.1",
+                "data-uri-to-buffer": "8.0.0",
+                "debug": "^4.3.4"
+            },
+            "engines": {
+                "node": ">= 20"
+            }
+        },
+        "node_modules/puppeteer/node_modules/http-proxy-agent": {
+            "version": "9.1.0",
+            "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-9.1.0.tgz",
+            "integrity": "sha512-2NxoveTT58mjYT4n3RPTEfCZGLMbidoO8XEieXfpSYxu+PQJ1qpx4ypwH6N+uF9twBPIvRRgvkvW5HUTYWENig==",
+            "license": "MIT",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "agent-base": "9.0.0",
+                "debug": "^4.3.4",
+                "proxy-agent-negotiate": "1.1.0"
+            },
+            "engines": {
+                "node": ">= 20"
+            }
+        },
+        "node_modules/puppeteer/node_modules/https-proxy-agent": {
+            "version": "9.1.0",
+            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-9.1.0.tgz",
+            "integrity": "sha512-ag87y7cJJ9/3+GxFr8Oy4O5faDsGRGnBGsJj/YjOSsSx/5eadKLYTMPlzuR6obgoCDDm0abAAZitXXQkMOPSpA==",
+            "license": "MIT",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "agent-base": "9.0.0",
+                "debug": "^4.3.4",
+                "proxy-agent-negotiate": "1.1.0"
+            },
+            "engines": {
+                "node": ">= 20"
+            }
+        },
+        "node_modules/puppeteer/node_modules/lru-cache": {
+            "version": "7.18.3",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
+            "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
+            "license": "ISC",
+            "optional": true,
+            "peer": true,
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/puppeteer/node_modules/pac-proxy-agent": {
+            "version": "9.1.0",
+            "resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-9.1.0.tgz",
+            "integrity": "sha512-1aU+1mpj3DrQPfo3gh+3Gap3G5x+axnMx1P/y0ZF2ch7kb2meyOCAH8K2k9d27ROsTE7TnAerzxqF9aon2jqnA==",
+            "license": "MIT",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "agent-base": "9.0.0",
+                "debug": "^4.3.4",
+                "get-uri": "8.0.1",
+                "http-proxy-agent": "9.1.0",
+                "https-proxy-agent": "9.1.0",
+                "pac-resolver": "9.0.1",
+                "quickjs-wasi": "^2.2.0",
+                "socks-proxy-agent": "10.1.0"
+            },
+            "engines": {
+                "node": ">= 20"
+            }
+        },
+        "node_modules/puppeteer/node_modules/pac-resolver": {
+            "version": "9.0.1",
+            "resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-9.0.1.tgz",
+            "integrity": "sha512-lJbS008tmkj08VhoM8Hzuv/VE5tK9MS0OIQ/7+s0lIF+BYhiQWFYzkSpML7lXs9iBu2jfmzBTLzhe9n6BX+dYw==",
+            "license": "MIT",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "degenerator": "7.0.1",
+                "netmask": "^2.0.2"
+            },
+            "engines": {
+                "node": ">= 20"
+            },
+            "peerDependencies": {
+                "quickjs-wasi": "^2.2.0"
+            }
+        },
+        "node_modules/puppeteer/node_modules/proxy-agent": {
+            "version": "8.0.2",
+            "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-8.0.2.tgz",
+            "integrity": "sha512-idLLRewuemWd7GH/BDJzGiB0dWGfT2SQs3jy6NtZtGWU9uPTTSdeC1/cdbqLwgzhfv027daGFuXX426e2Eg20A==",
+            "license": "MIT",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "agent-base": "9.0.0",
+                "debug": "^4.3.4",
+                "http-proxy-agent": "9.1.0",
+                "https-proxy-agent": "9.1.0",
+                "lru-cache": "^7.14.1",
+                "pac-proxy-agent": "9.1.0",
+                "proxy-from-env": "^2.0.0",
+                "socks-proxy-agent": "10.1.0"
+            },
+            "engines": {
+                "node": ">= 20"
+            }
+        },
+        "node_modules/puppeteer/node_modules/proxy-from-env": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+            "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+            "license": "MIT",
+            "optional": true,
+            "peer": true,
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/puppeteer/node_modules/socks-proxy-agent": {
+            "version": "10.1.0",
+            "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-10.1.0.tgz",
+            "integrity": "sha512-WlMj/67cEJ6MDI1OcsnjuYKDNDoyPCCYZ249kuuXPiMDw9F8PXkVaQ7YWu3siTydfQ/4BEZcvGzu+aYvz7dDCQ==",
+            "license": "MIT",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "agent-base": "9.0.0",
+                "debug": "^4.3.4",
+                "socks": "^2.8.3"
+            },
+            "engines": {
+                "node": ">= 20"
+            }
         },
         "node_modules/puppeteer/node_modules/string-width": {
             "version": "7.2.0",
@@ -12462,6 +12896,14 @@
             "version": "4.0.4",
             "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
             "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg=="
+        },
+        "node_modules/quickjs-wasi": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/quickjs-wasi/-/quickjs-wasi-2.2.0.tgz",
+            "integrity": "sha512-zQxXmQMrEoD3S+jQdYsloq4qAuaxKFHZj6hHqOYGwB2iQZH+q9e/lf5zQPXCKOk0WJuAjzRFbO4KwHIp2D05Iw==",
+            "license": "MIT",
+            "optional": true,
+            "peer": true
         },
         "node_modules/railroad-diagrams": {
             "version": "1.0.0",

--- a/functions/src/api/routes/whatsapp/cloudTasks.ts
+++ b/functions/src/api/routes/whatsapp/cloudTasks.ts
@@ -1,0 +1,94 @@
+import fb from 'firebase-admin'
+import { PanelTaskPayload } from './whatsappPanelTask'
+
+// The reminder tasks live in the Cloud Tasks queue Firebase creates for the onTaskDispatched function
+// (queue id === function name), in the same region it is deployed to. We talk to the Cloud Tasks REST
+// API directly (authenticated with the admin SDK's access token) to avoid pulling the heavy
+// @google-cloud/tasks client just for list/delete.
+const LOCATION = 'europe-west1'
+const QUEUE_ID = 'sendWhatsappPanel'
+const API_BASE = 'https://cloudtasks.googleapis.com/v2'
+
+export type ScheduledPanel = { name: string; scheduleTime: string | null; message: string }
+
+const projectId = (app: fb.app.App): string => {
+    const id =
+        app.options.projectId ||
+        process.env.GCLOUD_PROJECT ||
+        process.env.GCP_PROJECT ||
+        process.env.GOOGLE_CLOUD_PROJECT
+    if (!id) throw new Error('Project id not found in environment')
+    return id
+}
+
+// The admin SDK credential yields an OAuth token scoped for cloud-platform, which Cloud Tasks accepts.
+const accessToken = async (app: fb.app.App): Promise<string> => {
+    const credential = app.options.credential ?? fb.credential.applicationDefault()
+    const { access_token } = await credential.getAccessToken()
+    return access_token
+}
+
+const queuePath = (app: fb.app.App): string => `projects/${projectId(app)}/locations/${LOCATION}/queues/${QUEUE_ID}`
+
+// `path` is a resource path (e.g. "projects/.../tasks/123"), optionally with a query string.
+const apiFetch = async (app: fb.app.App, path: string, init: RequestInit = {}): Promise<any> => {
+    const res = await fetch(`${API_BASE}/${path}`, {
+        ...init,
+        headers: {
+            Authorization: `Bearer ${await accessToken(app)}`,
+            'Content-Type': 'application/json',
+            ...(init.headers || {}),
+        },
+    })
+    const text = await res.text()
+    if (!res.ok) {
+        throw new Error(`Cloud Tasks ${init.method || 'GET'} failed (${res.status}): ${text}`)
+    }
+    return text ? JSON.parse(text) : {}
+}
+
+// Firebase enqueues the payload as the JSON body `{ data: <payload> }` (base64 in the REST response);
+// tolerate a bare payload too.
+const decodePayload = (bodyBase64: unknown): PanelTaskPayload | null => {
+    if (typeof bodyBase64 !== 'string' || bodyBase64.length === 0) return null
+    try {
+        const parsed = JSON.parse(Buffer.from(bodyBase64, 'base64').toString('utf8'))
+        return (parsed?.data ?? parsed) as PanelTaskPayload
+    } catch {
+        return null
+    }
+}
+
+// Lists the still-pending reminder tasks for one event, soonest first.
+export const listScheduledPanels = async (app: fb.app.App, eventId: string): Promise<ScheduledPanel[]> => {
+    const out: ScheduledPanel[] = []
+    let pageToken: string | undefined
+    // Few tasks per queue, but page through to be correct.
+    do {
+        const query = `responseView=FULL&pageSize=100${pageToken ? `&pageToken=${encodeURIComponent(pageToken)}` : ''}`
+        const data = await apiFetch(app, `${queuePath(app)}/tasks?${query}`)
+        for (const task of data.tasks || []) {
+            const payload = decodePayload(task?.httpRequest?.body)
+            if (!payload || payload.eventId !== eventId) continue
+            out.push({ name: String(task.name), scheduleTime: task.scheduleTime || null, message: payload.message })
+        }
+        pageToken = data.nextPageToken || undefined
+    } while (pageToken)
+
+    return out.sort((a, b) => (a.scheduleTime || '').localeCompare(b.scheduleTime || ''))
+}
+
+// Deletes a single reminder task, but only if it belongs to this event's queue (guards against
+// deleting another queue's / another event's task via a forged name).
+export const deleteScheduledPanel = async (app: fb.app.App, eventId: string, name: string): Promise<boolean> => {
+    if (!name.startsWith(`${queuePath(app)}/tasks/`)) return false
+    try {
+        const task = await apiFetch(app, `${name}?responseView=FULL`)
+        const payload = decodePayload(task?.httpRequest?.body)
+        if (!payload || payload.eventId !== eventId) return false
+    } catch {
+        return false
+    }
+    await apiFetch(app, name, { method: 'DELETE' })
+    return true
+}

--- a/functions/src/api/routes/whatsapp/greenApi.ts
+++ b/functions/src/api/routes/whatsapp/greenApi.ts
@@ -7,6 +7,14 @@ export type GreenApiCreds = {
     token: string
 }
 
+export const credsFromEvent = (event: {
+    greenApiInstanceId?: string | null
+    greenApiToken?: string | null
+}): GreenApiCreds | null => {
+    if (!event.greenApiInstanceId || !event.greenApiToken) return null
+    return { instanceId: event.greenApiInstanceId, token: event.greenApiToken }
+}
+
 const call = async (creds: GreenApiCreds, method: string, payload: unknown): Promise<any> => {
     const url = `${GREEN_API_BASE}/waInstance${creds.instanceId}/${method}/${creds.token}`
     const res = await fetch(url, {

--- a/functions/src/api/routes/whatsapp/greenApi.ts
+++ b/functions/src/api/routes/whatsapp/greenApi.ts
@@ -1,0 +1,66 @@
+// Thin GreenAPI (WhatsApp) client. Each instance also has its own host, but the shared gateway
+// routes by instance id, so no per-event URL is needed.
+const GREEN_API_BASE = 'https://api.green-api.com'
+
+export type GreenApiCreds = {
+    instanceId: string
+    token: string
+}
+
+export type InteractiveButton = {
+    buttonId: string
+    buttonText: string
+}
+
+const call = async (creds: GreenApiCreds, method: string, payload: unknown): Promise<any> => {
+    const url = `${GREEN_API_BASE}/waInstance${creds.instanceId}/${method}/${creds.token}`
+    const res = await fetch(url, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+    })
+    const text = await res.text()
+    if (!res.ok) {
+        throw new Error(`GreenAPI ${method} failed (${res.status}): ${text}`)
+    }
+    return text ? JSON.parse(text) : {}
+}
+
+// A WhatsApp chatId for a person is the phone number (digits only, country code included) + "@c.us".
+// A value that already looks like a chatId (contains "@") is passed through untouched.
+export const toChatId = (raw: string): string => {
+    if (raw.includes('@')) return raw
+    return `${raw.replace(/[^0-9]/g, '')}@c.us`
+}
+
+export const sendMessage = async (creds: GreenApiCreds, chatId: string, message: string): Promise<string> => {
+    const data = await call(creds, 'sendMessage', { chatId, message })
+    return data.idMessage
+}
+
+// https://green-api.com/en/docs/api/sending/SendInteractiveButtonsReply/ — max 3 buttons per message.
+export const sendInteractiveButtons = async (
+    creds: GreenApiCreds,
+    chatId: string,
+    body: string,
+    buttons: InteractiveButton[],
+    header?: string
+): Promise<string> => {
+    const data = await call(creds, 'sendInteractiveButtonsReply', {
+        chatId,
+        ...(header ? { header } : {}),
+        body,
+        buttons: buttons.slice(0, 3).map((b) => ({ type: 'reply', buttonId: b.buttonId, buttonText: b.buttonText })),
+    })
+    return data.idMessage
+}
+
+// https://green-api.com/en/docs/api/sending/EditMessage/ — replaces the message text (buttons drop off).
+export const editMessage = async (
+    creds: GreenApiCreds,
+    chatId: string,
+    idMessage: string,
+    message: string
+): Promise<void> => {
+    await call(creds, 'editMessage', { chatId, idMessage, message })
+}

--- a/functions/src/api/routes/whatsapp/greenApi.ts
+++ b/functions/src/api/routes/whatsapp/greenApi.ts
@@ -33,6 +33,20 @@ export const toChatId = (raw: string): string => {
     return `${raw.replace(/[^0-9]/g, '')}@c.us`
 }
 
+// Configure the instance to call our webhook for incoming messages. GreenAPI sends webhookUrlToken
+// back as the "Authorization: Bearer <token>" header. NB: changing settings reboots the instance
+// (it can be unavailable for a few minutes afterwards).
+export const setSettings = async (
+    creds: GreenApiCreds,
+    settings: { webhookUrl: string; webhookUrlToken: string }
+): Promise<void> => {
+    await call(creds, 'setSettings', {
+        webhookUrl: settings.webhookUrl,
+        webhookUrlToken: settings.webhookUrlToken,
+        incomingWebhook: 'yes',
+    })
+}
+
 export const sendMessage = async (creds: GreenApiCreds, chatId: string, message: string): Promise<string> => {
     const data = await call(creds, 'sendMessage', { chatId, message })
     return data.idMessage

--- a/functions/src/api/routes/whatsapp/greenApi.ts
+++ b/functions/src/api/routes/whatsapp/greenApi.ts
@@ -29,11 +29,39 @@ const call = async (creds: GreenApiCreds, method: string, payload: unknown): Pro
     return text ? JSON.parse(text) : {}
 }
 
+const callGet = async (creds: GreenApiCreds, method: string): Promise<any> => {
+    const url = `${GREEN_API_BASE}/waInstance${creds.instanceId}/${method}/${creds.token}`
+    const res = await fetch(url)
+    const text = await res.text()
+    if (!res.ok) {
+        throw new Error(`GreenAPI ${method} failed (${res.status}): ${text}`)
+    }
+    return text ? JSON.parse(text) : {}
+}
+
 // A WhatsApp chatId for a person is the phone number (digits only, country code included) + "@c.us".
 // A value that already looks like a chatId (contains "@") is passed through untouched.
 export const toChatId = (raw: string): string => {
     if (raw.includes('@')) return raw
     return `${raw.replace(/[^0-9]/g, '')}@c.us`
+}
+
+// A WhatsApp chat as exposed to the admin UI. `type` is 'group' for group chats (id ends @g.us)
+// and 'user' for single contacts (id ends @c.us).
+export type GreenApiContact = { id: string; name: string; type: 'group' | 'user' }
+
+// https://green-api.com/en/docs/api/chats/GetChats/ — lists every chat and group the instance has.
+// Used so the operator can pick the shared chat / test recipient instead of pasting a raw chatId.
+export const getChats = async (creds: GreenApiCreds): Promise<GreenApiContact[]> => {
+    const data = await callGet(creds, 'getChats')
+    if (!Array.isArray(data)) return []
+    return data
+        .map((c: any) => {
+            const id = String(c?.id ?? '')
+            const type: 'group' | 'user' = id.endsWith('@g.us') ? 'group' : 'user'
+            return { id, name: String(c?.name || c?.contactName || id), type }
+        })
+        .filter((c) => c.id.length > 0)
 }
 
 export const sendMessage = async (creds: GreenApiCreds, chatId: string, message: string): Promise<string> => {

--- a/functions/src/api/routes/whatsapp/greenApi.ts
+++ b/functions/src/api/routes/whatsapp/greenApi.ts
@@ -7,11 +7,6 @@ export type GreenApiCreds = {
     token: string
 }
 
-export type InteractiveButton = {
-    buttonId: string
-    buttonText: string
-}
-
 const call = async (creds: GreenApiCreds, method: string, payload: unknown): Promise<any> => {
     const url = `${GREEN_API_BASE}/waInstance${creds.instanceId}/${method}/${creds.token}`
     const res = await fetch(url, {
@@ -33,9 +28,32 @@ export const toChatId = (raw: string): string => {
     return `${raw.replace(/[^0-9]/g, '')}@c.us`
 }
 
-// Configure the instance to call our webhook for incoming messages. GreenAPI sends webhookUrlToken
-// back as the "Authorization: Bearer <token>" header. NB: changing settings reboots the instance
-// (it can be unavailable for a few minutes afterwards).
+export const sendMessage = async (creds: GreenApiCreds, chatId: string, message: string): Promise<string> => {
+    const data = await call(creds, 'sendMessage', { chatId, message })
+    return data.idMessage
+}
+
+// https://green-api.com/en/docs/api/sending/SendPoll/ — WhatsApp polls allow up to 12 options.
+// Unlike interactive buttons, poll votes DO produce incoming (pollUpdateMessage) webhooks.
+export const sendPoll = async (
+    creds: GreenApiCreds,
+    chatId: string,
+    question: string,
+    options: string[],
+    multipleAnswers = true
+): Promise<string> => {
+    const data = await call(creds, 'sendPoll', {
+        chatId,
+        message: question,
+        options: options.slice(0, 12).map((name) => ({ optionName: name })),
+        multipleAnswers,
+    })
+    return data.idMessage
+}
+
+// Configure the instance to call our webhook for incoming messages (poll votes included). GreenAPI
+// sends webhookUrlToken back as the "Authorization: Bearer <token>" header. NB: changing settings
+// reboots the instance (it can be unavailable for a few minutes afterwards).
 export const setSettings = async (
     creds: GreenApiCreds,
     settings: { webhookUrl: string; webhookUrlToken: string }
@@ -44,37 +62,6 @@ export const setSettings = async (
         webhookUrl: settings.webhookUrl,
         webhookUrlToken: settings.webhookUrlToken,
         incomingWebhook: 'yes',
+        pollMessageWebhook: 'yes',
     })
-}
-
-export const sendMessage = async (creds: GreenApiCreds, chatId: string, message: string): Promise<string> => {
-    const data = await call(creds, 'sendMessage', { chatId, message })
-    return data.idMessage
-}
-
-// https://green-api.com/en/docs/api/sending/SendInteractiveButtonsReply/ — max 3 buttons per message.
-export const sendInteractiveButtons = async (
-    creds: GreenApiCreds,
-    chatId: string,
-    body: string,
-    buttons: InteractiveButton[],
-    header?: string
-): Promise<string> => {
-    const data = await call(creds, 'sendInteractiveButtonsReply', {
-        chatId,
-        ...(header ? { header } : {}),
-        body,
-        buttons: buttons.slice(0, 3).map((b) => ({ buttonId: b.buttonId, buttonText: b.buttonText })),
-    })
-    return data.idMessage
-}
-
-// https://green-api.com/en/docs/api/sending/EditMessage/ — replaces the message text (buttons drop off).
-export const editMessage = async (
-    creds: GreenApiCreds,
-    chatId: string,
-    idMessage: string,
-    message: string
-): Promise<void> => {
-    await call(creds, 'editMessage', { chatId, idMessage, message })
 }

--- a/functions/src/api/routes/whatsapp/greenApi.ts
+++ b/functions/src/api/routes/whatsapp/greenApi.ts
@@ -50,7 +50,7 @@ export const sendInteractiveButtons = async (
         chatId,
         ...(header ? { header } : {}),
         body,
-        buttons: buttons.slice(0, 3).map((b) => ({ type: 'reply', buttonId: b.buttonId, buttonText: b.buttonText })),
+        buttons: buttons.slice(0, 3).map((b) => ({ buttonId: b.buttonId, buttonText: b.buttonText })),
     })
     return data.idMessage
 }

--- a/functions/src/api/routes/whatsapp/trackFlow.test.ts
+++ b/functions/src/api/routes/whatsapp/trackFlow.test.ts
@@ -1,75 +1,62 @@
 import { describe, expect, test, vi } from 'vitest'
-import { handleTrackReady, startTrackSession, WhatsappSenders } from './trackFlow'
+import { applyPollVotes, startTrackSession, WhatsappSenders } from './trackFlow'
 
-// Fake senders: record calls, hand back incrementing message ids.
 const makeSenders = () => {
     let n = 0
-    const sendInteractiveButtons = vi.fn(async () => `msg-${++n}`)
-    const editMessage = vi.fn(async () => {})
+    const sendPoll = vi.fn(async () => `poll-${++n}`)
     const sendMessage = vi.fn(async () => `txt-${++n}`)
-    const senders: WhatsappSenders = { sendInteractiveButtons, editMessage, sendMessage }
-    return { senders, sendInteractiveButtons, editMessage, sendMessage }
+    const senders: WhatsappSenders = { sendPoll, sendMessage }
+    return { senders, sendPoll, sendMessage }
 }
 
 const tracks = (n: number) => Array.from({ length: n }, (_, i) => ({ id: `t${i + 1}`, name: `Track ${i + 1}` }))
 
 describe('startTrackSession', () => {
-    test('chunks tracks into messages of at most 3 buttons', async () => {
-        const { senders, sendInteractiveButtons } = makeSenders()
+    test('sends one poll for up to 12 tracks', async () => {
+        const { senders, sendPoll } = makeSenders()
         const session = await startTrackSession(tracks(5), '123@c.us', senders)
 
-        expect(sendInteractiveButtons).toHaveBeenCalledTimes(2) // 5 tracks -> [3, 2]
-        expect(session.messages.map((m) => m.trackIds)).toEqual([
-            ['t1', 't2', 't3'],
-            ['t4', 't5'],
-        ])
+        expect(sendPoll).toHaveBeenCalledTimes(1)
+        expect(sendPoll.mock.calls[0][2]).toEqual(['Track 1', 'Track 2', 'Track 3', 'Track 4', 'Track 5'])
+        expect(session.pollMessageIds).toEqual(['poll-1'])
         expect(session.tracks.every((t) => !t.ready)).toBe(true)
         expect(session.goSent).toBe(false)
+    })
 
-        const firstButtons = sendInteractiveButtons.mock.calls[0][2]
-        expect(firstButtons).toHaveLength(3)
-        expect(firstButtons[0]).toMatchObject({ buttonId: 't1', buttonText: 'Track 1' })
+    test('splits into multiple polls beyond 12 options', async () => {
+        const { senders, sendPoll } = makeSenders()
+        const session = await startTrackSession(tracks(13), 'c@c.us', senders)
+        expect(sendPoll).toHaveBeenCalledTimes(2) // 13 -> [12, 1]
+        expect(session.pollMessageIds).toHaveLength(2)
     })
 })
 
-describe('handleTrackReady', () => {
-    test('marks the track ready, edits its message and re-offers the still-pending buttons', async () => {
-        const { senders, editMessage, sendInteractiveButtons } = makeSenders()
+describe('applyPollVotes', () => {
+    test('marks voted tracks ready (matched by option name)', async () => {
+        const { senders } = makeSenders()
         const session = await startTrackSession(tracks(3), 'c@c.us', senders)
-        sendInteractiveButtons.mockClear()
 
-        await handleTrackReady(session, 't1', senders)
+        await applyPollVotes(session, ['Track 1'], senders)
 
         expect(session.tracks.find((t) => t.id === 't1')!.ready).toBe(true)
-        expect(editMessage).toHaveBeenCalledTimes(1) // original 3-button message edited to a recap
-        // remaining pending (t2, t3) get a fresh 2-button message
-        expect(sendInteractiveButtons).toHaveBeenCalledTimes(1)
-        expect(sendInteractiveButtons.mock.calls[0][2].map((b: any) => b.buttonId)).toEqual(['t2', 't3'])
-        expect(session.messages).toEqual([{ idMessage: expect.any(String), trackIds: ['t2', 't3'] }])
+        expect(session.tracks.find((t) => t.id === 't2')!.ready).toBe(false)
     })
 
-    test('sends GO exactly once when the last track becomes ready', async () => {
+    test('readiness is sticky and GO is sent once when all are ready', async () => {
         const { senders, sendMessage } = makeSenders()
         const session = await startTrackSession(tracks(2), 'c@c.us', senders)
 
-        await handleTrackReady(session, 't1', senders)
+        await applyPollVotes(session, ['Track 1'], senders)
         expect(sendMessage).not.toHaveBeenCalled()
-        expect(session.goSent).toBe(false)
 
-        await handleTrackReady(session, 't2', senders)
+        // A later update without Track 1's voter must not un-ready it.
+        await applyPollVotes(session, ['Track 2'], senders)
+        expect(session.tracks.every((t) => t.ready)).toBe(true)
         expect(sendMessage).toHaveBeenCalledTimes(1)
         expect(session.goSent).toBe(true)
-        expect(session.messages).toHaveLength(0)
-    })
 
-    test('is idempotent for a track that is already ready', async () => {
-        const { senders, editMessage } = makeSenders()
-        const session = await startTrackSession(tracks(2), 'c@c.us', senders)
-
-        await handleTrackReady(session, 't1', senders)
-        editMessage.mockClear()
-        await handleTrackReady(session, 't1', senders) // duplicate press
-
-        expect(editMessage).not.toHaveBeenCalled()
+        // Further updates don't resend GO.
+        await applyPollVotes(session, ['Track 1', 'Track 2'], senders)
+        expect(sendMessage).toHaveBeenCalledTimes(1)
     })
 })

--- a/functions/src/api/routes/whatsapp/trackFlow.test.ts
+++ b/functions/src/api/routes/whatsapp/trackFlow.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test, vi } from 'vitest'
-import { applyPollVotes, startTrackSession, WhatsappSenders } from './trackFlow'
+import { applyPollVotes, sendGoMessage, startTrackSession, WhatsappSenders } from './trackFlow'
 
 const makeSenders = () => {
     let n = 0
@@ -36,27 +36,37 @@ describe('applyPollVotes', () => {
         const { senders } = makeSenders()
         const session = await startTrackSession(tracks(3), 'c@c.us', senders)
 
-        await applyPollVotes(session, ['Track 1'], senders)
+        applyPollVotes(session, ['Track 1'])
 
         expect(session.tracks.find((t) => t.id === 't1')!.ready).toBe(true)
         expect(session.tracks.find((t) => t.id === 't2')!.ready).toBe(false)
     })
 
-    test('readiness is sticky and GO is sent once when all are ready', async () => {
+    test('readiness is sticky and never sends GO on its own', async () => {
         const { senders, sendMessage } = makeSenders()
         const session = await startTrackSession(tracks(2), 'c@c.us', senders)
 
-        await applyPollVotes(session, ['Track 1'], senders)
+        applyPollVotes(session, ['Track 1'])
         expect(sendMessage).not.toHaveBeenCalled()
 
         // A later update without Track 1's voter must not un-ready it.
-        await applyPollVotes(session, ['Track 2'], senders)
+        applyPollVotes(session, ['Track 2'])
         expect(session.tracks.every((t) => t.ready)).toBe(true)
-        expect(sendMessage).toHaveBeenCalledTimes(1)
-        expect(session.goSent).toBe(true)
+        expect(sendMessage).not.toHaveBeenCalled()
+        expect(session.goSent).toBe(false)
+    })
+})
 
-        // Further updates don't resend GO.
-        await applyPollVotes(session, ['Track 1', 'Track 2'], senders)
+describe('sendGoMessage', () => {
+    test('sends the GO message and flags the session as sent', async () => {
+        const { senders, sendMessage } = makeSenders()
+        const session = await startTrackSession(tracks(2), 'c@c.us', senders)
+        applyPollVotes(session, ['Track 1', 'Track 2'])
+
+        const updated = await sendGoMessage(session, senders)
+
         expect(sendMessage).toHaveBeenCalledTimes(1)
+        expect(sendMessage).toHaveBeenCalledWith('c@c.us', expect.stringContaining('GO'))
+        expect(updated.goSent).toBe(true)
     })
 })

--- a/functions/src/api/routes/whatsapp/trackFlow.test.ts
+++ b/functions/src/api/routes/whatsapp/trackFlow.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, test, vi } from 'vitest'
+import { handleTrackReady, startTrackSession, WhatsappSenders } from './trackFlow'
+
+// Fake senders: record calls, hand back incrementing message ids.
+const makeSenders = () => {
+    let n = 0
+    const sendInteractiveButtons = vi.fn(async () => `msg-${++n}`)
+    const editMessage = vi.fn(async () => {})
+    const sendMessage = vi.fn(async () => `txt-${++n}`)
+    const senders: WhatsappSenders = { sendInteractiveButtons, editMessage, sendMessage }
+    return { senders, sendInteractiveButtons, editMessage, sendMessage }
+}
+
+const tracks = (n: number) => Array.from({ length: n }, (_, i) => ({ id: `t${i + 1}`, name: `Track ${i + 1}` }))
+
+describe('startTrackSession', () => {
+    test('chunks tracks into messages of at most 3 buttons', async () => {
+        const { senders, sendInteractiveButtons } = makeSenders()
+        const session = await startTrackSession(tracks(5), '123@c.us', senders)
+
+        expect(sendInteractiveButtons).toHaveBeenCalledTimes(2) // 5 tracks -> [3, 2]
+        expect(session.messages.map((m) => m.trackIds)).toEqual([
+            ['t1', 't2', 't3'],
+            ['t4', 't5'],
+        ])
+        expect(session.tracks.every((t) => !t.ready)).toBe(true)
+        expect(session.goSent).toBe(false)
+
+        const firstButtons = sendInteractiveButtons.mock.calls[0][2]
+        expect(firstButtons).toHaveLength(3)
+        expect(firstButtons[0]).toMatchObject({ buttonId: 't1', buttonText: 'Track 1' })
+    })
+})
+
+describe('handleTrackReady', () => {
+    test('marks the track ready, edits its message and re-offers the still-pending buttons', async () => {
+        const { senders, editMessage, sendInteractiveButtons } = makeSenders()
+        const session = await startTrackSession(tracks(3), 'c@c.us', senders)
+        sendInteractiveButtons.mockClear()
+
+        await handleTrackReady(session, 't1', senders)
+
+        expect(session.tracks.find((t) => t.id === 't1')!.ready).toBe(true)
+        expect(editMessage).toHaveBeenCalledTimes(1) // original 3-button message edited to a recap
+        // remaining pending (t2, t3) get a fresh 2-button message
+        expect(sendInteractiveButtons).toHaveBeenCalledTimes(1)
+        expect(sendInteractiveButtons.mock.calls[0][2].map((b: any) => b.buttonId)).toEqual(['t2', 't3'])
+        expect(session.messages).toEqual([{ idMessage: expect.any(String), trackIds: ['t2', 't3'] }])
+    })
+
+    test('sends GO exactly once when the last track becomes ready', async () => {
+        const { senders, sendMessage } = makeSenders()
+        const session = await startTrackSession(tracks(2), 'c@c.us', senders)
+
+        await handleTrackReady(session, 't1', senders)
+        expect(sendMessage).not.toHaveBeenCalled()
+        expect(session.goSent).toBe(false)
+
+        await handleTrackReady(session, 't2', senders)
+        expect(sendMessage).toHaveBeenCalledTimes(1)
+        expect(session.goSent).toBe(true)
+        expect(session.messages).toHaveLength(0)
+    })
+
+    test('is idempotent for a track that is already ready', async () => {
+        const { senders, editMessage } = makeSenders()
+        const session = await startTrackSession(tracks(2), 'c@c.us', senders)
+
+        await handleTrackReady(session, 't1', senders)
+        editMessage.mockClear()
+        await handleTrackReady(session, 't1', senders) // duplicate press
+
+        expect(editMessage).not.toHaveBeenCalled()
+    })
+})

--- a/functions/src/api/routes/whatsapp/trackFlow.test.ts
+++ b/functions/src/api/routes/whatsapp/trackFlow.test.ts
@@ -36,24 +36,49 @@ describe('applyPollVotes', () => {
         const { senders } = makeSenders()
         const session = await startTrackSession(tracks(3), 'c@c.us', senders)
 
-        applyPollVotes(session, ['Track 1'])
+        applyPollVotes(session, [
+            { name: 'Track 1', ready: true },
+            { name: 'Track 2', ready: false },
+            { name: 'Track 3', ready: false },
+        ])
 
         expect(session.tracks.find((t) => t.id === 't1')!.ready).toBe(true)
         expect(session.tracks.find((t) => t.id === 't2')!.ready).toBe(false)
     })
 
-    test('readiness is sticky and never sends GO on its own', async () => {
+    test('cancelling a vote un-readies the track and never sends GO on its own', async () => {
         const { senders, sendMessage } = makeSenders()
         const session = await startTrackSession(tracks(2), 'c@c.us', senders)
 
-        applyPollVotes(session, ['Track 1'])
-        expect(sendMessage).not.toHaveBeenCalled()
+        applyPollVotes(session, [
+            { name: 'Track 1', ready: true },
+            { name: 'Track 2', ready: false },
+        ])
+        expect(session.tracks.find((t) => t.id === 't1')!.ready).toBe(true)
 
-        // A later update without Track 1's voter must not un-ready it.
-        applyPollVotes(session, ['Track 2'])
-        expect(session.tracks.every((t) => t.ready)).toBe(true)
+        // The voter removes their vote: the same poll now reports Track 1 with no voters.
+        applyPollVotes(session, [
+            { name: 'Track 1', ready: false },
+            { name: 'Track 2', ready: false },
+        ])
+        expect(session.tracks.find((t) => t.id === 't1')!.ready).toBe(false)
         expect(sendMessage).not.toHaveBeenCalled()
         expect(session.goSent).toBe(false)
+    })
+
+    test('only updates tracks that are options in this poll (multi-poll split)', async () => {
+        const { senders } = makeSenders()
+        const session = await startTrackSession(tracks(2), 'c@c.us', senders)
+
+        // Each track voted ready via its own poll message.
+        applyPollVotes(session, [{ name: 'Track 1', ready: true }])
+        applyPollVotes(session, [{ name: 'Track 2', ready: true }])
+        expect(session.tracks.every((t) => t.ready)).toBe(true)
+
+        // An update for the first poll must not touch Track 2 (a different poll message).
+        applyPollVotes(session, [{ name: 'Track 1', ready: false }])
+        expect(session.tracks.find((t) => t.id === 't1')!.ready).toBe(false)
+        expect(session.tracks.find((t) => t.id === 't2')!.ready).toBe(true)
     })
 })
 
@@ -61,7 +86,10 @@ describe('sendGoMessage', () => {
     test('sends the GO message and flags the session as sent', async () => {
         const { senders, sendMessage } = makeSenders()
         const session = await startTrackSession(tracks(2), 'c@c.us', senders)
-        applyPollVotes(session, ['Track 1', 'Track 2'])
+        applyPollVotes(session, [
+            { name: 'Track 1', ready: true },
+            { name: 'Track 2', ready: true },
+        ])
 
         const updated = await sendGoMessage(session, senders)
 

--- a/functions/src/api/routes/whatsapp/trackFlow.ts
+++ b/functions/src/api/routes/whatsapp/trackFlow.ts
@@ -27,15 +27,21 @@ export const startTrackSession = async (
     return { chatId, tracks: trackStates, pollMessageIds, goSent: false, panelsSent: [] }
 }
 
-// Apply a poll vote update: tracks whose option got at least one vote become ready (sticky — a track
-// stays ready even if a voter later removes their vote). The GO message is no longer sent
-// automatically — see sendGoMessage, triggered manually from the admin UI.
-export const applyPollVotes = (session: TrackSession, votedOptionNames: string[]): TrackSession => {
-    const voted = new Set(votedOptionNames)
+// Apply a poll vote snapshot for one poll message. GreenAPI sends the full current vote state, so each
+// track that is an option in this poll is set ready iff it currently has at least one voter — meaning
+// cancelling a vote un-readies the track. Tracks that aren't options in this poll (when >12 tracks were
+// split across several poll messages) are left untouched. GO is never sent automatically — see
+// sendGoMessage, triggered manually from the admin UI.
+export const applyPollVotes = (
+    session: TrackSession,
+    optionStates: { name: string; ready: boolean }[]
+): TrackSession => {
+    const readyByName = new Map(optionStates.map((o) => [o.name, o.ready]))
 
     for (const track of session.tracks) {
-        if (!track.ready && voted.has(track.name)) {
-            track.ready = true
+        const ready = readyByName.get(track.name)
+        if (ready !== undefined) {
+            track.ready = ready
         }
     }
 

--- a/functions/src/api/routes/whatsapp/trackFlow.ts
+++ b/functions/src/api/routes/whatsapp/trackFlow.ts
@@ -24,7 +24,7 @@ export const startTrackSession = async (
         pollMessageIds.push(idMessage)
     }
 
-    return { chatId, tracks: trackStates, pollMessageIds, goSent: false }
+    return { chatId, tracks: trackStates, pollMessageIds, goSent: false, panelsSent: [] }
 }
 
 // Apply a poll vote update: tracks whose option got at least one vote become ready (sticky — a track

--- a/functions/src/api/routes/whatsapp/trackFlow.ts
+++ b/functions/src/api/routes/whatsapp/trackFlow.ts
@@ -1,0 +1,77 @@
+import { InteractiveButton } from './greenApi'
+import {
+    allReady,
+    BUTTONS_PER_MESSAGE,
+    buttonsForTracks,
+    ButtonMessage,
+    chunk,
+    goMessage,
+    pendingBody,
+    recapBody,
+    TrackSession,
+    TrackState,
+} from './trackSession'
+
+// Side effects are injected so the flow is unit-testable without Firebase or the network.
+export type WhatsappSenders = {
+    sendInteractiveButtons: (chatId: string, body: string, buttons: InteractiveButton[]) => Promise<string>
+    editMessage: (chatId: string, idMessage: string, message: string) => Promise<void>
+    sendMessage: (chatId: string, message: string) => Promise<string>
+}
+
+// Start a track-management session: send one interactive message per group of <=3 tracks.
+export const startTrackSession = async (
+    tracks: { id: string; name: string }[],
+    chatId: string,
+    senders: WhatsappSenders
+): Promise<TrackSession> => {
+    const trackStates: TrackState[] = tracks.map((t) => ({ id: t.id, name: t.name, ready: false }))
+    const messages: ButtonMessage[] = []
+
+    for (const group of chunk(trackStates, BUTTONS_PER_MESSAGE)) {
+        const idMessage = await senders.sendInteractiveButtons(chatId, pendingBody(group), buttonsForTracks(group))
+        messages.push({ idMessage, trackIds: group.map((t) => t.id) })
+    }
+
+    return { chatId, tracks: trackStates, messages, goSent: false }
+}
+
+// Handle one track confirming ready: mark it, update its (now button-less) message, re-offer buttons for
+// the tracks still pending in that group, and send GO once every track is ready.
+export const handleTrackReady = async (
+    session: TrackSession,
+    pressedTrackId: string,
+    senders: WhatsappSenders
+): Promise<TrackSession> => {
+    const track = session.tracks.find((t) => t.id === pressedTrackId)
+    if (!track || track.ready) {
+        return session
+    }
+    track.ready = true
+
+    const byId = (id: string) => session.tracks.find((t) => t.id === id)!
+    const message = session.messages.find((m) => m.trackIds.includes(pressedTrackId))
+
+    if (message) {
+        const groupTracks = message.trackIds.map(byId)
+        await senders.editMessage(session.chatId, message.idMessage, recapBody(groupTracks))
+        session.messages = session.messages.filter((m) => m !== message)
+
+        const stillPending = groupTracks.filter((t) => !t.ready)
+        if (stillPending.length > 0) {
+            const idMessage = await senders.sendInteractiveButtons(
+                session.chatId,
+                pendingBody(stillPending),
+                buttonsForTracks(stillPending)
+            )
+            session.messages.push({ idMessage, trackIds: stillPending.map((t) => t.id) })
+        }
+    }
+
+    if (!session.goSent && allReady(session.tracks)) {
+        await senders.sendMessage(session.chatId, goMessage(session.tracks))
+        session.goSent = true
+    }
+
+    return session
+}

--- a/functions/src/api/routes/whatsapp/trackFlow.ts
+++ b/functions/src/api/routes/whatsapp/trackFlow.ts
@@ -1,70 +1,44 @@
-import { InteractiveButton } from './greenApi'
-import {
-    allReady,
-    BUTTONS_PER_MESSAGE,
-    buttonsForTracks,
-    ButtonMessage,
-    chunk,
-    goMessage,
-    pendingBody,
-    recapBody,
-    TrackSession,
-    TrackState,
-} from './trackSession'
+import { allReady, chunk, goMessage, OPTIONS_PER_POLL, POLL_QUESTION, TrackSession, TrackState } from './trackSession'
 
 // Side effects are injected so the flow is unit-testable without Firebase or the network.
 export type WhatsappSenders = {
-    sendInteractiveButtons: (chatId: string, body: string, buttons: InteractiveButton[]) => Promise<string>
-    editMessage: (chatId: string, idMessage: string, message: string) => Promise<void>
+    sendPoll: (chatId: string, question: string, options: string[]) => Promise<string>
     sendMessage: (chatId: string, message: string) => Promise<string>
 }
 
-// Start a track-management session: send one interactive message per group of <=3 tracks.
+// Start a track-management session: send one poll per group of up to 12 tracks.
 export const startTrackSession = async (
     tracks: { id: string; name: string }[],
     chatId: string,
     senders: WhatsappSenders
 ): Promise<TrackSession> => {
     const trackStates: TrackState[] = tracks.map((t) => ({ id: t.id, name: t.name, ready: false }))
-    const messages: ButtonMessage[] = []
+    const pollMessageIds: string[] = []
 
-    for (const group of chunk(trackStates, BUTTONS_PER_MESSAGE)) {
-        const idMessage = await senders.sendInteractiveButtons(chatId, pendingBody(group), buttonsForTracks(group))
-        messages.push({ idMessage, trackIds: group.map((t) => t.id) })
+    for (const group of chunk(trackStates, OPTIONS_PER_POLL)) {
+        const idMessage = await senders.sendPoll(
+            chatId,
+            POLL_QUESTION,
+            group.map((t) => t.name)
+        )
+        pollMessageIds.push(idMessage)
     }
 
-    return { chatId, tracks: trackStates, messages, goSent: false }
+    return { chatId, tracks: trackStates, pollMessageIds, goSent: false }
 }
 
-// Handle one track confirming ready: mark it, update its (now button-less) message, re-offer buttons for
-// the tracks still pending in that group, and send GO once every track is ready.
-export const handleTrackReady = async (
+// Apply a poll vote update: tracks whose option got at least one vote become ready (sticky — a track
+// stays ready even if a voter later removes their vote). Sends GO once every track is ready.
+export const applyPollVotes = async (
     session: TrackSession,
-    pressedTrackId: string,
+    votedOptionNames: string[],
     senders: WhatsappSenders
 ): Promise<TrackSession> => {
-    const track = session.tracks.find((t) => t.id === pressedTrackId)
-    if (!track || track.ready) {
-        return session
-    }
-    track.ready = true
+    const voted = new Set(votedOptionNames)
 
-    const byId = (id: string) => session.tracks.find((t) => t.id === id)!
-    const message = session.messages.find((m) => m.trackIds.includes(pressedTrackId))
-
-    if (message) {
-        const groupTracks = message.trackIds.map(byId)
-        await senders.editMessage(session.chatId, message.idMessage, recapBody(groupTracks))
-        session.messages = session.messages.filter((m) => m !== message)
-
-        const stillPending = groupTracks.filter((t) => !t.ready)
-        if (stillPending.length > 0) {
-            const idMessage = await senders.sendInteractiveButtons(
-                session.chatId,
-                pendingBody(stillPending),
-                buttonsForTracks(stillPending)
-            )
-            session.messages.push({ idMessage, trackIds: stillPending.map((t) => t.id) })
+    for (const track of session.tracks) {
+        if (!track.ready && voted.has(track.name)) {
+            track.ready = true
         }
     }
 

--- a/functions/src/api/routes/whatsapp/trackFlow.ts
+++ b/functions/src/api/routes/whatsapp/trackFlow.ts
@@ -1,4 +1,4 @@
-import { allReady, chunk, goMessage, OPTIONS_PER_POLL, POLL_QUESTION, TrackSession, TrackState } from './trackSession'
+import { chunk, goMessage, OPTIONS_PER_POLL, POLL_QUESTION, TrackSession, TrackState } from './trackSession'
 
 // Side effects are injected so the flow is unit-testable without Firebase or the network.
 export type WhatsappSenders = {
@@ -28,12 +28,9 @@ export const startTrackSession = async (
 }
 
 // Apply a poll vote update: tracks whose option got at least one vote become ready (sticky — a track
-// stays ready even if a voter later removes their vote). Sends GO once every track is ready.
-export const applyPollVotes = async (
-    session: TrackSession,
-    votedOptionNames: string[],
-    senders: WhatsappSenders
-): Promise<TrackSession> => {
+// stays ready even if a voter later removes their vote). The GO message is no longer sent
+// automatically — see sendGoMessage, triggered manually from the admin UI.
+export const applyPollVotes = (session: TrackSession, votedOptionNames: string[]): TrackSession => {
     const voted = new Set(votedOptionNames)
 
     for (const track of session.tracks) {
@@ -42,10 +39,13 @@ export const applyPollVotes = async (
         }
     }
 
-    if (!session.goSent && allReady(session.tracks)) {
-        await senders.sendMessage(session.chatId, goMessage(session.tracks))
-        session.goSent = true
-    }
+    return session
+}
 
+// Manually broadcast the GO message. Caller is responsible for checking allReady(session.tracks)
+// and !session.goSent first (the admin route does, guarding against early/duplicate sends).
+export const sendGoMessage = async (session: TrackSession, senders: WhatsappSenders): Promise<TrackSession> => {
+    await senders.sendMessage(session.chatId, goMessage(session.tracks))
+    session.goSent = true
     return session
 }

--- a/functions/src/api/routes/whatsapp/trackSession.ts
+++ b/functions/src/api/routes/whatsapp/trackSession.ts
@@ -10,6 +10,8 @@ export type TrackSession = {
     // Poll message ids we sent (for reference; votes are matched back by option name).
     pollMessageIds: string[]
     goSent: boolean
+    // Messages from PANEL_SCHEDULE that the scheduled task has already sent for this session.
+    panelsSent: string[]
 }
 
 // WhatsApp polls allow at most 12 options; split tracks across polls if there are more.

--- a/functions/src/api/routes/whatsapp/trackSession.ts
+++ b/functions/src/api/routes/whatsapp/trackSession.ts
@@ -1,25 +1,21 @@
-import { InteractiveButton } from './greenApi'
-
 export type TrackState = {
     id: string
     name: string
     ready: boolean
 }
 
-// An active interactive-buttons message and which tracks (still pending) it offers buttons for.
-export type ButtonMessage = {
-    idMessage: string
-    trackIds: string[]
-}
-
 export type TrackSession = {
     chatId: string
     tracks: TrackState[]
-    messages: ButtonMessage[]
+    // Poll message ids we sent (for reference; votes are matched back by option name).
+    pollMessageIds: string[]
     goSent: boolean
 }
 
-export const BUTTONS_PER_MESSAGE = 3
+// WhatsApp polls allow at most 12 options; split tracks across polls if there are more.
+export const OPTIONS_PER_POLL = 12
+
+export const POLL_QUESTION = 'Which tracks are ready? Tap your track.'
 
 export const chunk = <T>(items: T[], size: number): T[][] => {
     const out: T[][] = []
@@ -27,21 +23,6 @@ export const chunk = <T>(items: T[], size: number): T[][] => {
         out.push(items.slice(i, i + size))
     }
     return out
-}
-
-export const buttonsForTracks = (tracks: TrackState[]): InteractiveButton[] =>
-    tracks.map((t) => ({ buttonId: t.id, buttonText: t.name }))
-
-// Body text shown above the buttons on an active (pending) message.
-export const pendingBody = (tracks: TrackState[]): string => {
-    const names = tracks.map((t) => t.name).join(', ')
-    return `Tap your track when it is ready: ${names}`
-}
-
-// Recap text an edited message shows once a track in its group has confirmed (buttons are gone).
-export const recapBody = (tracks: TrackState[]): string => {
-    const lines = tracks.map((t) => `${t.ready ? '✅' : '⏳'} ${t.name}`)
-    return ['Track status', ...lines].join('\n')
 }
 
 export const allReady = (tracks: TrackState[]): boolean => tracks.length > 0 && tracks.every((t) => t.ready)

--- a/functions/src/api/routes/whatsapp/trackSession.ts
+++ b/functions/src/api/routes/whatsapp/trackSession.ts
@@ -29,3 +29,11 @@ export const allReady = (tracks: TrackState[]): boolean => tracks.length > 0 && 
 
 export const goMessage = (tracks: TrackState[]): string =>
     `🟢 GO — all ${tracks.length} tracks are ready. You can start.`
+
+// Timing reminders auto-scheduled when GO is sent, on a 50min session clock: 15/10/5 min left, then end.
+export const PANEL_SCHEDULE: { delaySeconds: number; message: string }[] = [
+    { delaySeconds: 35 * 60, message: 'Panneau 15 min' },
+    { delaySeconds: 40 * 60, message: 'Panneau 10 min' },
+    { delaySeconds: 45 * 60, message: 'Panneau 5 min' },
+    { delaySeconds: 50 * 60, message: 'Fin de session' },
+]

--- a/functions/src/api/routes/whatsapp/trackSession.ts
+++ b/functions/src/api/routes/whatsapp/trackSession.ts
@@ -1,0 +1,50 @@
+import { InteractiveButton } from './greenApi'
+
+export type TrackState = {
+    id: string
+    name: string
+    ready: boolean
+}
+
+// An active interactive-buttons message and which tracks (still pending) it offers buttons for.
+export type ButtonMessage = {
+    idMessage: string
+    trackIds: string[]
+}
+
+export type TrackSession = {
+    chatId: string
+    tracks: TrackState[]
+    messages: ButtonMessage[]
+    goSent: boolean
+}
+
+export const BUTTONS_PER_MESSAGE = 3
+
+export const chunk = <T>(items: T[], size: number): T[][] => {
+    const out: T[][] = []
+    for (let i = 0; i < items.length; i += size) {
+        out.push(items.slice(i, i + size))
+    }
+    return out
+}
+
+export const buttonsForTracks = (tracks: TrackState[]): InteractiveButton[] =>
+    tracks.map((t) => ({ buttonId: t.id, buttonText: t.name }))
+
+// Body text shown above the buttons on an active (pending) message.
+export const pendingBody = (tracks: TrackState[]): string => {
+    const names = tracks.map((t) => t.name).join(', ')
+    return `Tap your track when it is ready: ${names}`
+}
+
+// Recap text an edited message shows once a track in its group has confirmed (buttons are gone).
+export const recapBody = (tracks: TrackState[]): string => {
+    const lines = tracks.map((t) => `${t.ready ? '✅' : '⏳'} ${t.name}`)
+    return ['Track status', ...lines].join('\n')
+}
+
+export const allReady = (tracks: TrackState[]): boolean => tracks.length > 0 && tracks.every((t) => t.ready)
+
+export const goMessage = (tracks: TrackState[]): string =>
+    `🟢 GO — all ${tracks.length} tracks are ready. You can start.`

--- a/functions/src/api/routes/whatsapp/trackSession.ts
+++ b/functions/src/api/routes/whatsapp/trackSession.ts
@@ -29,8 +29,16 @@ export const chunk = <T>(items: T[], size: number): T[][] => {
 
 export const allReady = (tracks: TrackState[]): boolean => tracks.length > 0 && tracks.every((t) => t.ready)
 
-export const goMessage = (tracks: TrackState[]): string =>
-    `🟢 GO — all ${tracks.length} tracks are ready. You can start.`
+export const goMessage = (tracks: TrackState[]): string => {
+    const notReady = tracks.filter((t) => !t.ready)
+    if (notReady.length === 0) {
+        return     `🟢 GO — all ${tracks.length} tracks are ready. You can start.`
+}
+    // Forced GO: some tracks never confirmed ready. Be explicit about which ones.
+    const readyCount = tracks.length - notReady.length
+    const names = notReady.map((t) => t.name).join(', ')
+    return `🟢 GO — ${readyCount}/${tracks.length} tracks ready, starting anyway. Not ready: ${names}.`
+}
 
 // Timing reminders auto-scheduled when GO is sent, on a 50min session clock: 15/10/5 min left, then end.
 export const PANEL_SCHEDULE: { delaySeconds: number; message: string }[] = [

--- a/functions/src/api/routes/whatsapp/whatsapp.ts
+++ b/functions/src/api/routes/whatsapp/whatsapp.ts
@@ -22,14 +22,12 @@ const StartBody = Type.Object({
 })
 type StartBodyType = Static<typeof StartBody>
 
-const PanelMessageBody = Type.Object({ message: Type.String({ minLength: 1 }) })
-type PanelMessageBodyType = Static<typeof PanelMessageBody>
-
 // Explicit reply schema: a bare Type.Any() makes fast-json-stringify drop every field (returns {}).
 const StatusReply = Type.Object({
     chatId: Type.Union([Type.String(), Type.Null()]),
     tracks: Type.Array(Type.Object({ id: Type.String(), name: Type.String(), ready: Type.Boolean() })),
     goSent: Type.Boolean(),
+    panelsSent: Type.Array(Type.String()),
 })
 
 const authMatches = (header: string, expected: string): boolean =>
@@ -170,7 +168,14 @@ export const whatsappRoutes = (fastify: FastifyInstance, options: any, done: () 
         },
         async (request, reply) => {
             const session = await WhatsappSessionDao.getSession(fastify.firebase, request.params.eventId)
-            reply.status(200).send(session || { chatId: null, tracks: [], goSent: false })
+            // panelsSent defaults to [] for sessions created before that field existed.
+            reply
+                .status(200)
+                .send(
+                    session
+                        ? { ...session, panelsSent: session.panelsSent || [] }
+                        : { chatId: null, tracks: [], goSent: false, panelsSent: [] }
+                )
         }
     )
 
@@ -228,42 +233,6 @@ export const whatsappRoutes = (fastify: FastifyInstance, options: any, done: () 
                 )
             } catch (err) {
                 request.log?.error({ err }, 'failed to schedule whatsapp panel reminders')
-            }
-        }
-    )
-
-    // --- Send a free-form message to the shared chat (e.g. timing panels) ---
-    fastify.post<{ Params: { eventId: string }; Body: PanelMessageBodyType }>(
-        '/v1/:eventId/whatsapp/track-management/message',
-        {
-            schema: {
-                tags: ['whatsapp'],
-                summary: 'Send a free-form message (e.g. a timing panel) to the shared chat.',
-                params: Type.Object({ eventId: Type.String() }),
-                body: PanelMessageBody,
-                response: { 200: Type.Object({ sent: Type.Boolean() }), 400: Type.String(), 401: Type.String() },
-                security: [{ apiKey: [] }],
-            },
-            preHandler: fastify.auth([fastify.verifyApiKey]),
-        },
-        async (request, reply) => {
-            const { eventId } = request.params
-            const event = await EventDao.getEvent(fastify.firebase, eventId)
-            const creds = credsFromEvent(event)
-            if (!creds) {
-                reply.status(400).send(JSON.stringify({ error: 'GreenAPI is not configured for this event.' }))
-                return
-            }
-            const session = await WhatsappSessionDao.getSession(fastify.firebase, eventId)
-            if (!session?.chatId) {
-                reply.status(400).send(JSON.stringify({ error: 'No track-management session in progress.' }))
-                return
-            }
-            try {
-                await sendMessage(creds, session.chatId, request.body.message)
-                reply.status(200).send({ sent: true })
-            } catch (err) {
-                reply.status(400).send(JSON.stringify({ error: 'Failed to send', details: (err as Error).message }))
             }
         }
     )

--- a/functions/src/api/routes/whatsapp/whatsapp.ts
+++ b/functions/src/api/routes/whatsapp/whatsapp.ts
@@ -1,17 +1,12 @@
 import { FastifyInstance } from 'fastify'
 import Type, { Static } from 'typebox'
+import { getFunctions } from 'firebase-admin/functions'
 import { EventDao } from '../../dao/eventDao'
-import { GreenApiCreds, sendMessage, sendPoll, setSettings, toChatId } from './greenApi'
-import { WhatsappSenders, applyPollVotes, startTrackSession } from './trackFlow'
+import { GreenApiCreds, credsFromEvent, sendMessage, sendPoll, setSettings, toChatId } from './greenApi'
+import { WhatsappSenders, applyPollVotes, sendGoMessage, startTrackSession } from './trackFlow'
+import { allReady, PANEL_SCHEDULE } from './trackSession'
 import { WhatsappSessionDao } from './whatsappSessionDao'
-
-const credsFromEvent = (event: {
-    greenApiInstanceId?: string | null
-    greenApiToken?: string | null
-}): GreenApiCreds | null => {
-    if (!event.greenApiInstanceId || !event.greenApiToken) return null
-    return { instanceId: event.greenApiInstanceId, token: event.greenApiToken }
-}
+import { PanelTaskPayload, sendWhatsappPanelTaskName } from './whatsappPanelTask'
 
 // Bind the injected senders to creds so the flow code stays free of GreenAPI details.
 const sendersFor = (creds: GreenApiCreds): WhatsappSenders => ({
@@ -26,6 +21,9 @@ const StartBody = Type.Object({
     chatId: Type.String({ description: 'Shared chat that receives the track poll (phone or group chatId)' }),
 })
 type StartBodyType = Static<typeof StartBody>
+
+const PanelMessageBody = Type.Object({ message: Type.String({ minLength: 1 }) })
+type PanelMessageBodyType = Static<typeof PanelMessageBody>
 
 // Explicit reply schema: a bare Type.Any() makes fast-json-stringify drop every field (returns {}).
 const StatusReply = Type.Object({
@@ -176,6 +174,100 @@ export const whatsappRoutes = (fastify: FastifyInstance, options: any, done: () 
         }
     )
 
+    // --- Manually broadcast the GO message once every track is ready ---
+    fastify.post<{ Params: { eventId: string } }>(
+        '/v1/:eventId/whatsapp/track-management/go',
+        {
+            schema: {
+                tags: ['whatsapp'],
+                summary: 'Send the GO message to the shared chat (only once every track is ready).',
+                params: Type.Object({ eventId: Type.String() }),
+                response: { 200: Type.Object({ sent: Type.Boolean() }), 400: Type.String(), 401: Type.String() },
+                security: [{ apiKey: [] }],
+            },
+            preHandler: fastify.auth([fastify.verifyApiKey]),
+        },
+        async (request, reply) => {
+            const { eventId } = request.params
+            const event = await EventDao.getEvent(fastify.firebase, eventId)
+            const creds = credsFromEvent(event)
+            if (!creds) {
+                reply.status(400).send(JSON.stringify({ error: 'GreenAPI is not configured for this event.' }))
+                return
+            }
+            const session = await WhatsappSessionDao.getSession(fastify.firebase, eventId)
+            if (!session) {
+                reply.status(400).send(JSON.stringify({ error: 'No track-management session in progress.' }))
+                return
+            }
+            if (session.goSent) {
+                reply.status(400).send(JSON.stringify({ error: 'GO message was already sent.' }))
+                return
+            }
+            if (!allReady(session.tracks)) {
+                reply.status(400).send(JSON.stringify({ error: 'Not every track is ready yet.' }))
+                return
+            }
+            try {
+                const updated = await sendGoMessage(session, sendersFor(creds))
+                await WhatsappSessionDao.saveSession(fastify.firebase, eventId, updated)
+                reply.status(200).send({ sent: true })
+            } catch (err) {
+                reply.status(400).send(JSON.stringify({ error: 'Failed to send GO', details: (err as Error).message }))
+                return
+            }
+
+            // Best-effort: schedule the timing reminders. GO was already broadcast, so a scheduling
+            // failure here shouldn't turn into an error response — just log it.
+            try {
+                const taskQueue = getFunctions(fastify.firebase).taskQueue<PanelTaskPayload>(sendWhatsappPanelTaskName)
+                await Promise.all(
+                    PANEL_SCHEDULE.map(({ delaySeconds, message }) =>
+                        taskQueue.enqueue({ eventId, message }, { scheduleDelaySeconds: delaySeconds })
+                    )
+                )
+            } catch (err) {
+                request.log?.error({ err }, 'failed to schedule whatsapp panel reminders')
+            }
+        }
+    )
+
+    // --- Send a free-form message to the shared chat (e.g. timing panels) ---
+    fastify.post<{ Params: { eventId: string }; Body: PanelMessageBodyType }>(
+        '/v1/:eventId/whatsapp/track-management/message',
+        {
+            schema: {
+                tags: ['whatsapp'],
+                summary: 'Send a free-form message (e.g. a timing panel) to the shared chat.',
+                params: Type.Object({ eventId: Type.String() }),
+                body: PanelMessageBody,
+                response: { 200: Type.Object({ sent: Type.Boolean() }), 400: Type.String(), 401: Type.String() },
+                security: [{ apiKey: [] }],
+            },
+            preHandler: fastify.auth([fastify.verifyApiKey]),
+        },
+        async (request, reply) => {
+            const { eventId } = request.params
+            const event = await EventDao.getEvent(fastify.firebase, eventId)
+            const creds = credsFromEvent(event)
+            if (!creds) {
+                reply.status(400).send(JSON.stringify({ error: 'GreenAPI is not configured for this event.' }))
+                return
+            }
+            const session = await WhatsappSessionDao.getSession(fastify.firebase, eventId)
+            if (!session?.chatId) {
+                reply.status(400).send(JSON.stringify({ error: 'No track-management session in progress.' }))
+                return
+            }
+            try {
+                await sendMessage(creds, session.chatId, request.body.message)
+                reply.status(200).send({ sent: true })
+            } catch (err) {
+                reply.status(400).send(JSON.stringify({ error: 'Failed to send', details: (err as Error).message }))
+            }
+        }
+    )
+
     // --- GreenAPI incoming webhook, event-scoped. GreenAPI must be configured to send an
     //     Authorization header equal to the event apiKey (raw or "Bearer <key>"). Poll votes arrive
     //     as messageData.typeMessage === "pollUpdateMessage". ---
@@ -209,10 +301,9 @@ export const whatsappRoutes = (fastify: FastifyInstance, options: any, done: () 
                     reply.status(401).send({ error: 'Unauthorized webhook' })
                     return
                 }
-                const creds = credsFromEvent(event)
                 const session = await WhatsappSessionDao.getSession(fastify.firebase, eventId)
-                if (creds && session && votedOptionNames.length > 0) {
-                    const updated = await applyPollVotes(session, votedOptionNames, sendersFor(creds))
+                if (session && votedOptionNames.length > 0) {
+                    const updated = applyPollVotes(session, votedOptionNames)
                     await WhatsappSessionDao.saveSession(fastify.firebase, eventId, updated)
                 }
             }

--- a/functions/src/api/routes/whatsapp/whatsapp.ts
+++ b/functions/src/api/routes/whatsapp/whatsapp.ts
@@ -1,8 +1,8 @@
 import { FastifyInstance } from 'fastify'
 import Type, { Static } from 'typebox'
 import { EventDao } from '../../dao/eventDao'
-import { GreenApiCreds, editMessage, sendInteractiveButtons, sendMessage, setSettings, toChatId } from './greenApi'
-import { WhatsappSenders, handleTrackReady, startTrackSession } from './trackFlow'
+import { GreenApiCreds, sendMessage, sendPoll, setSettings, toChatId } from './greenApi'
+import { WhatsappSenders, applyPollVotes, startTrackSession } from './trackFlow'
 import { WhatsappSessionDao } from './whatsappSessionDao'
 
 const credsFromEvent = (event: {
@@ -13,21 +13,17 @@ const credsFromEvent = (event: {
     return { instanceId: event.greenApiInstanceId, token: event.greenApiToken }
 }
 
-// Bind the injected senders to a chat + creds so the flow code stays free of GreenAPI details.
+// Bind the injected senders to creds so the flow code stays free of GreenAPI details.
 const sendersFor = (creds: GreenApiCreds): WhatsappSenders => ({
-    sendInteractiveButtons: (chatId, body, buttons) => sendInteractiveButtons(creds, chatId, body, buttons),
-    editMessage: (chatId, idMessage, message) => editMessage(creds, chatId, idMessage, message),
+    sendPoll: (chatId, question, options) => sendPoll(creds, chatId, question, options),
     sendMessage: (chatId, message) => sendMessage(creds, chatId, message),
 })
 
-const SendBody = Type.Object({
-    to: Type.String(),
-    message: Type.String({ minLength: 1 }),
-})
+const SendBody = Type.Object({ to: Type.String(), message: Type.String({ minLength: 1 }) })
 type SendBodyType = Static<typeof SendBody>
 
 const StartBody = Type.Object({
-    chatId: Type.String({ description: 'Shared chat that receives the track buttons (phone or group chatId)' }),
+    chatId: Type.String({ description: 'Shared chat that receives the track poll (phone or group chatId)' }),
 })
 type StartBodyType = Static<typeof StartBody>
 
@@ -35,9 +31,11 @@ type StartBodyType = Static<typeof StartBody>
 const StatusReply = Type.Object({
     chatId: Type.Union([Type.String(), Type.Null()]),
     tracks: Type.Array(Type.Object({ id: Type.String(), name: Type.String(), ready: Type.Boolean() })),
-    messages: Type.Array(Type.Object({ idMessage: Type.String(), trackIds: Type.Array(Type.String()) })),
     goSent: Type.Boolean(),
 })
+
+const authMatches = (header: string, expected: string): boolean =>
+    Boolean(expected) && (header === expected || header === `Bearer ${expected}`)
 
 export const whatsappRoutes = (fastify: FastifyInstance, options: any, done: () => any) => {
     // --- Test send: a single plain message to validate the GreenAPI setup ---
@@ -79,13 +77,13 @@ export const whatsappRoutes = (fastify: FastifyInstance, options: any, done: () 
         }
     )
 
-    // --- Start track management: send chunked interactive button messages to the shared chat ---
+    // --- Start track management: send the track poll(s) to the shared chat ---
     fastify.post<{ Params: { eventId: string }; Body: StartBodyType }>(
         '/v1/:eventId/whatsapp/track-management/start',
         {
             schema: {
                 tags: ['whatsapp'],
-                summary: 'Send the per-track "ready?" interactive buttons (max 3 per message) to the shared chat.',
+                summary: 'Send the "which tracks are ready?" poll(s) (max 12 options each) to the shared chat.',
                 params: Type.Object({ eventId: Type.String() }),
                 body: StartBody,
                 response: {
@@ -121,13 +119,13 @@ export const whatsappRoutes = (fastify: FastifyInstance, options: any, done: () 
         }
     )
 
-    // --- Configure the GreenAPI instance to call our webhook (URL + auth token + incoming on) ---
+    // --- Configure the GreenAPI instance to call our (event-scoped) webhook ---
     fastify.post<{ Params: { eventId: string }; Body: { webhookUrl: string } }>(
         '/v1/:eventId/whatsapp/configure-webhook',
         {
             schema: {
                 tags: ['whatsapp'],
-                summary: 'Point the GreenAPI instance at our webhook so button taps are received (reboots instance).',
+                summary: 'Point the GreenAPI instance at our webhook so poll votes are received (reboots instance).',
                 params: Type.Object({ eventId: Type.String() }),
                 body: Type.Object({ webhookUrl: Type.String() }),
                 response: { 200: Type.Object({ configured: Type.Boolean() }), 400: Type.String(), 401: Type.String() },
@@ -149,7 +147,6 @@ export const whatsappRoutes = (fastify: FastifyInstance, options: any, done: () 
                 return
             }
             try {
-                // webhookUrlToken = apiKey, so GreenAPI sends "Authorization: Bearer <apiKey>" we verify below.
                 await setSettings(creds, { webhookUrl: request.body.webhookUrl, webhookUrlToken: event.apiKey })
                 reply.status(200).send({ configured: true })
             } catch (err) {
@@ -175,62 +172,55 @@ export const whatsappRoutes = (fastify: FastifyInstance, options: any, done: () 
         },
         async (request, reply) => {
             const session = await WhatsappSessionDao.getSession(fastify.firebase, request.params.eventId)
-            reply.status(200).send(session || { chatId: null, tracks: [], messages: [], goSent: false })
+            reply.status(200).send(session || { chatId: null, tracks: [], goSent: false })
         }
     )
 
-    // --- GreenAPI incoming webhook (global, no eventId; mapped via instance id). GreenAPI must be
-    //     configured to send an Authorization header equal to the event apiKey (raw or "Bearer <key>")
-    //     so forged button presses are rejected. ---
-    fastify.post('/v1/whatsapp/webhook', async (request, reply) => {
+    // --- GreenAPI incoming webhook, event-scoped. GreenAPI must be configured to send an
+    //     Authorization header equal to the event apiKey (raw or "Bearer <key>"). Poll votes arrive
+    //     as messageData.typeMessage === "pollUpdateMessage". ---
+    fastify.post<{ Params: { eventId: string } }>('/v1/:eventId/whatsapp/webhook', async (request, reply) => {
+        const { eventId } = request.params
         const body = (request.body || {}) as any
         const authHeader = (request.headers['authorization'] as string | undefined) || ''
 
         try {
-            const instanceId = body?.instanceData?.idInstance
-            const selectedButtonId =
-                body?.messageData?.interactiveButtonsReply?.buttonId ||
-                body?.messageData?.interactiveButtonsReply?.selectedButtonId ||
-                body?.messageData?.buttonsResponseMessage?.selectedButtonId ||
-                body?.messageData?.templateButtonReplyMessage?.selectedId
+            const md = body?.messageData
+            const votes: any[] = md?.pollMessageData?.votes || []
+            const votedOptionNames = votes
+                .filter((v) => (v?.optionVoters?.length || 0) > 0)
+                .map((v) => v?.optionName)
+                .filter(Boolean)
 
-            // Log every call so a "press did nothing" can be traced: did GreenAPI call us, with what
-            // type, did we extract a button id, was the auth header present.
             request.log?.info(
                 {
+                    eventId,
                     typeWebhook: body?.typeWebhook,
-                    typeMessage: body?.messageData?.typeMessage,
-                    instanceId,
-                    selectedButtonId,
+                    typeMessage: md?.typeMessage,
+                    votedOptionNames,
                     hasAuth: Boolean(authHeader),
                 },
                 'whatsapp webhook received'
             )
 
-            if (instanceId && selectedButtonId) {
-                const found = await WhatsappSessionDao.findEventByInstanceId(fastify.firebase, String(instanceId))
-                const expected = found?.event.apiKey || ''
-
-                // Reject anything that doesn't carry the event's secret in the Authorization header.
-                if (!found || !expected || (authHeader !== expected && authHeader !== `Bearer ${expected}`)) {
+            if (md?.typeMessage === 'pollUpdateMessage') {
+                const event = await EventDao.getEvent(fastify.firebase, eventId)
+                if (!event.apiKey || !authMatches(authHeader, event.apiKey)) {
                     reply.status(401).send({ error: 'Unauthorized webhook' })
                     return
                 }
-
-                const creds = credsFromEvent(found.event)
-                if (creds) {
-                    const session = await WhatsappSessionDao.getSession(fastify.firebase, found.id)
-                    if (session) {
-                        const updated = await handleTrackReady(session, String(selectedButtonId), sendersFor(creds))
-                        await WhatsappSessionDao.saveSession(fastify.firebase, found.id, updated)
-                    }
+                const creds = credsFromEvent(event)
+                const session = await WhatsappSessionDao.getSession(fastify.firebase, eventId)
+                if (creds && session && votedOptionNames.length > 0) {
+                    const updated = await applyPollVotes(session, votedOptionNames, sendersFor(creds))
+                    await WhatsappSessionDao.saveSession(fastify.firebase, eventId, updated)
                 }
             }
         } catch (err) {
             request.log?.error({ err }, 'whatsapp webhook failed')
         }
 
-        // 200 for non-button events (status updates, plain messages) so GreenAPI does not retry them.
+        // 200 for everything else (status pings, plain messages) so GreenAPI does not retry.
         reply.status(200).send({ received: true })
     })
 

--- a/functions/src/api/routes/whatsapp/whatsapp.ts
+++ b/functions/src/api/routes/whatsapp/whatsapp.ts
@@ -132,12 +132,13 @@ export const whatsappRoutes = (fastify: FastifyInstance, options: any, done: () 
         }
     )
 
-    // --- GreenAPI incoming webhook (global, no eventId; mapped via instance id). No apiKey: GreenAPI
-    //     calls it. It only acts on a button reply that matches a known event + session. ---
+    // --- GreenAPI incoming webhook (global, no eventId; mapped via instance id). GreenAPI must be
+    //     configured to send an Authorization header equal to the event apiKey (raw or "Bearer <key>")
+    //     so forged button presses are rejected. ---
     fastify.post('/v1/whatsapp/webhook', async (request, reply) => {
         const body = (request.body || {}) as any
+        const authHeader = (request.headers['authorization'] as string | undefined) || ''
 
-        // Always 200 quickly so GreenAPI does not retry; do the work but never surface internals.
         try {
             const instanceId = body?.instanceData?.idInstance
             const selectedButtonId =
@@ -148,8 +149,16 @@ export const whatsappRoutes = (fastify: FastifyInstance, options: any, done: () 
 
             if (instanceId && selectedButtonId) {
                 const found = await WhatsappSessionDao.findEventByInstanceId(fastify.firebase, String(instanceId))
-                const creds = found && credsFromEvent(found.event)
-                if (found && creds) {
+                const expected = found?.event.apiKey || ''
+
+                // Reject anything that doesn't carry the event's secret in the Authorization header.
+                if (!found || !expected || (authHeader !== expected && authHeader !== `Bearer ${expected}`)) {
+                    reply.status(401).send({ error: 'Unauthorized webhook' })
+                    return
+                }
+
+                const creds = credsFromEvent(found.event)
+                if (creds) {
                     const session = await WhatsappSessionDao.getSession(fastify.firebase, found.id)
                     if (session) {
                         const updated = await handleTrackReady(session, String(selectedButtonId), sendersFor(creds))
@@ -161,6 +170,7 @@ export const whatsappRoutes = (fastify: FastifyInstance, options: any, done: () 
             request.log?.error({ err }, 'whatsapp webhook failed')
         }
 
+        // 200 for non-button events (status updates, plain messages) so GreenAPI does not retry them.
         reply.status(200).send({ received: true })
     })
 

--- a/functions/src/api/routes/whatsapp/whatsapp.ts
+++ b/functions/src/api/routes/whatsapp/whatsapp.ts
@@ -224,7 +224,10 @@ export const whatsappRoutes = (fastify: FastifyInstance, options: any, done: () 
     )
 
     // --- Manually broadcast the GO message once every track is ready ---
-    fastify.post<{ Params: { eventId: string }; Body: { panels?: string[]; force?: boolean } }>(
+    fastify.post<{
+        Params: { eventId: string }
+        Body: { panels?: { message: string; delaySeconds: number }[]; force?: boolean }
+    }>(
         '/v1/:eventId/whatsapp/track-management/go',
         {
             schema: {
@@ -233,8 +236,8 @@ export const whatsappRoutes = (fastify: FastifyInstance, options: any, done: () 
                 params: Type.Object({ eventId: Type.String() }),
                 body: Type.Object({
                     panels: Type.Optional(
-                        Type.Array(Type.String(), {
-                            description: 'Reminder messages to auto-schedule. Omit to schedule all of them.',
+                        Type.Array(Type.Object({ message: Type.String(), delaySeconds: Type.Number() }), {
+                            description: 'Reminder messages to auto-schedule with their delays. Omit to schedule all.',
                         })
                     ),
                     force: Type.Optional(
@@ -279,11 +282,9 @@ export const whatsappRoutes = (fastify: FastifyInstance, options: any, done: () 
             // Best-effort: schedule the timing reminders. GO was already broadcast, so a scheduling
             // failure here shouldn't turn into an error response — just log it.
             try {
-                // Default to all reminders; when the client sends an explicit list, schedule only those.
-                const requested = request.body?.panels
-                const schedule = Array.isArray(requested)
-                    ? PANEL_SCHEDULE.filter((p) => requested.includes(p.message))
-                    : PANEL_SCHEDULE
+                // Default to all reminders; when the client sends an explicit list (with delays), use
+                // those directly so the frontend-configured timing is authoritative.
+                const schedule = Array.isArray(request.body?.panels) ? request.body.panels : PANEL_SCHEDULE
                 const taskQueue = getFunctions(fastify.firebase).taskQueue<PanelTaskPayload>(sendWhatsappPanelTaskName)
                 await Promise.all(
                     schedule.map(({ delaySeconds, message }) =>

--- a/functions/src/api/routes/whatsapp/whatsapp.ts
+++ b/functions/src/api/routes/whatsapp/whatsapp.ts
@@ -1,0 +1,98 @@
+import { FastifyInstance } from 'fastify'
+import Type, { Static } from 'typebox'
+import { EventDao } from '../../dao/eventDao'
+
+// GreenAPI universal gateway. Each instance also has its own host (e.g. https://7105.api.greenapi.com),
+// but the shared gateway routes to the right instance from the id, so no per-event URL is needed.
+const GREEN_API_BASE = 'https://api.green-api.com'
+
+// A WhatsApp chatId for a person is the phone number (digits only, country code included) + "@c.us".
+const toChatId = (raw: string): string => {
+    const digits = raw.replace(/[^0-9]/g, '')
+    return `${digits}@c.us`
+}
+
+const SendBody = Type.Object({
+    to: Type.String({ description: 'Recipient phone number, international format (digits, country code included)' }),
+    message: Type.String({ minLength: 1 }),
+})
+type SendBodyType = Static<typeof SendBody>
+
+const SendReply = Type.Object({
+    sent: Type.Boolean(),
+    idMessage: Type.Optional(Type.String()),
+})
+type SendReplyType = Static<typeof SendReply>
+
+export const whatsappRoutes = (fastify: FastifyInstance, options: any, done: () => any) => {
+    fastify.post<{ Params: { eventId: string }; Body: SendBodyType; Reply: SendReplyType | string }>(
+        '/v1/:eventId/whatsapp/send-test',
+        {
+            schema: {
+                tags: ['whatsapp'],
+                summary: 'Send a single WhatsApp message via the event GreenAPI instance (setup test).',
+                params: Type.Object({ eventId: Type.String() }),
+                body: SendBody,
+                response: {
+                    200: SendReply,
+                    400: Type.String(),
+                    401: Type.String(),
+                },
+                security: [{ apiKey: [] }],
+            },
+            preHandler: fastify.auth([fastify.verifyApiKey]),
+        },
+        async (request, reply) => {
+            const { eventId } = request.params
+            const { to, message } = request.body
+
+            const event = await EventDao.getEvent(fastify.firebase, eventId)
+
+            const instanceId = event.greenApiInstanceId
+            const token = event.greenApiToken
+            if (!instanceId || !token) {
+                reply.status(400).send(
+                    JSON.stringify({
+                        error: 'GreenAPI is not configured for this event. Set the instance id and token first.',
+                    })
+                )
+                return
+            }
+
+            if (!to || to.replace(/[^0-9]/g, '').length < 6) {
+                reply.status(400).send(JSON.stringify({ error: 'A valid recipient phone number is required.' }))
+                return
+            }
+
+            const url = `${GREEN_API_BASE}/waInstance${instanceId}/sendMessage/${token}`
+
+            try {
+                const res = await fetch(url, {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ chatId: toChatId(to), message }),
+                })
+
+                const text = await res.text()
+                if (!res.ok) {
+                    reply.status(400).send(
+                        JSON.stringify({
+                            error: 'GreenAPI rejected the request',
+                            status: res.status,
+                            details: text,
+                        })
+                    )
+                    return
+                }
+
+                const data = text ? (JSON.parse(text) as { idMessage?: string }) : {}
+                reply.status(200).send({ sent: true, idMessage: data.idMessage })
+            } catch (err) {
+                const error = err as Error
+                reply.status(400).send(JSON.stringify({ error: 'Failed to reach GreenAPI', details: error.message }))
+            }
+        }
+    )
+
+    done()
+}

--- a/functions/src/api/routes/whatsapp/whatsapp.ts
+++ b/functions/src/api/routes/whatsapp/whatsapp.ts
@@ -1,7 +1,7 @@
 import { FastifyInstance } from 'fastify'
 import Type, { Static } from 'typebox'
 import { EventDao } from '../../dao/eventDao'
-import { GreenApiCreds, editMessage, sendInteractiveButtons, sendMessage, toChatId } from './greenApi'
+import { GreenApiCreds, editMessage, sendInteractiveButtons, sendMessage, setSettings, toChatId } from './greenApi'
 import { WhatsappSenders, handleTrackReady, startTrackSession } from './trackFlow'
 import { WhatsappSessionDao } from './whatsappSessionDao'
 
@@ -113,6 +113,45 @@ export const whatsappRoutes = (fastify: FastifyInstance, options: any, done: () 
         }
     )
 
+    // --- Configure the GreenAPI instance to call our webhook (URL + auth token + incoming on) ---
+    fastify.post<{ Params: { eventId: string }; Body: { webhookUrl: string } }>(
+        '/v1/:eventId/whatsapp/configure-webhook',
+        {
+            schema: {
+                tags: ['whatsapp'],
+                summary: 'Point the GreenAPI instance at our webhook so button taps are received (reboots instance).',
+                params: Type.Object({ eventId: Type.String() }),
+                body: Type.Object({ webhookUrl: Type.String() }),
+                response: { 200: Type.Object({ configured: Type.Boolean() }), 400: Type.String(), 401: Type.String() },
+                security: [{ apiKey: [] }],
+            },
+            preHandler: fastify.auth([fastify.verifyApiKey]),
+        },
+        async (request, reply) => {
+            const event = await EventDao.getEvent(fastify.firebase, request.params.eventId)
+            const creds = credsFromEvent(event)
+            if (!creds) {
+                reply.status(400).send(JSON.stringify({ error: 'GreenAPI is not configured for this event.' }))
+                return
+            }
+            if (!event.apiKey) {
+                reply
+                    .status(400)
+                    .send(JSON.stringify({ error: 'Generate an event API key first (used as the webhook token).' }))
+                return
+            }
+            try {
+                // webhookUrlToken = apiKey, so GreenAPI sends "Authorization: Bearer <apiKey>" we verify below.
+                await setSettings(creds, { webhookUrl: request.body.webhookUrl, webhookUrlToken: event.apiKey })
+                reply.status(200).send({ configured: true })
+            } catch (err) {
+                reply
+                    .status(400)
+                    .send(JSON.stringify({ error: 'Failed to configure webhook', details: (err as Error).message }))
+            }
+        }
+    )
+
     // --- Status: current readiness, polled by the admin page ---
     fastify.get<{ Params: { eventId: string } }>(
         '/v1/:eventId/whatsapp/track-management/status',
@@ -146,6 +185,19 @@ export const whatsappRoutes = (fastify: FastifyInstance, options: any, done: () 
                 body?.messageData?.interactiveButtonsReply?.selectedButtonId ||
                 body?.messageData?.buttonsResponseMessage?.selectedButtonId ||
                 body?.messageData?.templateButtonReplyMessage?.selectedId
+
+            // Log every call so a "press did nothing" can be traced: did GreenAPI call us, with what
+            // type, did we extract a button id, was the auth header present.
+            request.log?.info(
+                {
+                    typeWebhook: body?.typeWebhook,
+                    typeMessage: body?.messageData?.typeMessage,
+                    instanceId,
+                    selectedButtonId,
+                    hasAuth: Boolean(authHeader),
+                },
+                'whatsapp webhook received'
+            )
 
             if (instanceId && selectedButtonId) {
                 const found = await WhatsappSessionDao.findEventByInstanceId(fastify.firebase, String(instanceId))

--- a/functions/src/api/routes/whatsapp/whatsapp.ts
+++ b/functions/src/api/routes/whatsapp/whatsapp.ts
@@ -2,9 +2,10 @@ import { FastifyInstance } from 'fastify'
 import Type, { Static } from 'typebox'
 import { getFunctions } from 'firebase-admin/functions'
 import { EventDao } from '../../dao/eventDao'
-import { GreenApiCreds, credsFromEvent, sendMessage, sendPoll, setSettings, toChatId } from './greenApi'
+import { GreenApiCreds, credsFromEvent, getChats, sendMessage, sendPoll, setSettings, toChatId } from './greenApi'
 import { WhatsappSenders, applyPollVotes, sendGoMessage, startTrackSession } from './trackFlow'
 import { allReady, PANEL_SCHEDULE } from './trackSession'
+import { deleteScheduledPanel, listScheduledPanels } from './cloudTasks'
 import { WhatsappSessionDao } from './whatsappSessionDao'
 import { PanelTaskPayload, sendWhatsappPanelTaskName } from './whatsappPanelTask'
 
@@ -115,6 +116,49 @@ export const whatsappRoutes = (fastify: FastifyInstance, options: any, done: () 
         }
     )
 
+    // --- List the GreenAPI chats/groups so the operator can pick a chat instead of pasting an id ---
+    fastify.get<{ Params: { eventId: string } }>(
+        '/v1/:eventId/whatsapp/contacts',
+        {
+            schema: {
+                tags: ['whatsapp'],
+                summary: 'List the WhatsApp chats and groups visible to the event GreenAPI instance.',
+                params: Type.Object({ eventId: Type.String() }),
+                response: {
+                    200: Type.Object({
+                        contacts: Type.Array(
+                            Type.Object({
+                                id: Type.String(),
+                                name: Type.String(),
+                                type: Type.Union([Type.Literal('group'), Type.Literal('user')]),
+                            })
+                        ),
+                    }),
+                    400: Type.String(),
+                    401: Type.String(),
+                },
+                security: [{ apiKey: [] }],
+            },
+            preHandler: fastify.auth([fastify.verifyApiKey]),
+        },
+        async (request, reply) => {
+            const event = await EventDao.getEvent(fastify.firebase, request.params.eventId)
+            const creds = credsFromEvent(event)
+            if (!creds) {
+                reply.status(400).send(JSON.stringify({ error: 'GreenAPI is not configured for this event.' }))
+                return
+            }
+            try {
+                const contacts = await getChats(creds)
+                reply.status(200).send({ contacts })
+            } catch (err) {
+                reply
+                    .status(400)
+                    .send(JSON.stringify({ error: 'Failed to fetch contacts', details: (err as Error).message }))
+            }
+        }
+    )
+
     // --- Configure the GreenAPI instance to call our (event-scoped) webhook ---
     fastify.post<{ Params: { eventId: string }; Body: { webhookUrl: string } }>(
         '/v1/:eventId/whatsapp/configure-webhook',
@@ -180,13 +224,23 @@ export const whatsappRoutes = (fastify: FastifyInstance, options: any, done: () 
     )
 
     // --- Manually broadcast the GO message once every track is ready ---
-    fastify.post<{ Params: { eventId: string } }>(
+    fastify.post<{ Params: { eventId: string }; Body: { panels?: string[]; force?: boolean } }>(
         '/v1/:eventId/whatsapp/track-management/go',
         {
             schema: {
                 tags: ['whatsapp'],
                 summary: 'Send the GO message to the shared chat (only once every track is ready).',
                 params: Type.Object({ eventId: Type.String() }),
+                body: Type.Object({
+                    panels: Type.Optional(
+                        Type.Array(Type.String(), {
+                            description: 'Reminder messages to auto-schedule. Omit to schedule all of them.',
+                        })
+                    ),
+                    force: Type.Optional(
+                        Type.Boolean({ description: 'Send GO even if not every track is ready yet.' })
+                    ),
+                }),
                 response: { 200: Type.Object({ sent: Type.Boolean() }), 400: Type.String(), 401: Type.String() },
                 security: [{ apiKey: [] }],
             },
@@ -209,7 +263,7 @@ export const whatsappRoutes = (fastify: FastifyInstance, options: any, done: () 
                 reply.status(400).send(JSON.stringify({ error: 'GO message was already sent.' }))
                 return
             }
-            if (!allReady(session.tracks)) {
+            if (!request.body?.force && !allReady(session.tracks)) {
                 reply.status(400).send(JSON.stringify({ error: 'Not every track is ready yet.' }))
                 return
             }
@@ -225,14 +279,86 @@ export const whatsappRoutes = (fastify: FastifyInstance, options: any, done: () 
             // Best-effort: schedule the timing reminders. GO was already broadcast, so a scheduling
             // failure here shouldn't turn into an error response — just log it.
             try {
+                // Default to all reminders; when the client sends an explicit list, schedule only those.
+                const requested = request.body?.panels
+                const schedule = Array.isArray(requested)
+                    ? PANEL_SCHEDULE.filter((p) => requested.includes(p.message))
+                    : PANEL_SCHEDULE
                 const taskQueue = getFunctions(fastify.firebase).taskQueue<PanelTaskPayload>(sendWhatsappPanelTaskName)
                 await Promise.all(
-                    PANEL_SCHEDULE.map(({ delaySeconds, message }) =>
+                    schedule.map(({ delaySeconds, message }) =>
                         taskQueue.enqueue({ eventId, message }, { scheduleDelaySeconds: delaySeconds })
                     )
                 )
             } catch (err) {
                 request.log?.error({ err }, 'failed to schedule whatsapp panel reminders')
+            }
+        }
+    )
+
+    // --- List the scheduled reminder tasks (Cloud Tasks) still pending for this event ---
+    fastify.get<{ Params: { eventId: string } }>(
+        '/v1/:eventId/whatsapp/scheduled-tasks',
+        {
+            schema: {
+                tags: ['whatsapp'],
+                summary: 'List the pending scheduled WhatsApp reminder tasks for the event.',
+                params: Type.Object({ eventId: Type.String() }),
+                response: {
+                    200: Type.Object({
+                        tasks: Type.Array(
+                            Type.Object({
+                                name: Type.String(),
+                                scheduleTime: Type.Union([Type.String(), Type.Null()]),
+                                message: Type.String(),
+                            })
+                        ),
+                    }),
+                    400: Type.String(),
+                    401: Type.String(),
+                },
+                security: [{ apiKey: [] }],
+            },
+            preHandler: fastify.auth([fastify.verifyApiKey]),
+        },
+        async (request, reply) => {
+            try {
+                const tasks = await listScheduledPanels(fastify.firebase, request.params.eventId)
+                reply.status(200).send({ tasks })
+            } catch (err) {
+                reply
+                    .status(400)
+                    .send(JSON.stringify({ error: 'Failed to list scheduled tasks', details: (err as Error).message }))
+            }
+        }
+    )
+
+    // --- Delete one pending scheduled reminder task ---
+    fastify.delete<{ Params: { eventId: string }; Body: { name: string } }>(
+        '/v1/:eventId/whatsapp/scheduled-tasks',
+        {
+            schema: {
+                tags: ['whatsapp'],
+                summary: 'Cancel a pending scheduled WhatsApp reminder task by its Cloud Tasks name.',
+                params: Type.Object({ eventId: Type.String() }),
+                body: Type.Object({ name: Type.String() }),
+                response: { 200: Type.Object({ deleted: Type.Boolean() }), 400: Type.String(), 401: Type.String() },
+                security: [{ apiKey: [] }],
+            },
+            preHandler: fastify.auth([fastify.verifyApiKey]),
+        },
+        async (request, reply) => {
+            try {
+                const deleted = await deleteScheduledPanel(fastify.firebase, request.params.eventId, request.body.name)
+                if (!deleted) {
+                    reply.status(400).send(JSON.stringify({ error: 'Task not found for this event.' }))
+                    return
+                }
+                reply.status(200).send({ deleted: true })
+            } catch (err) {
+                reply
+                    .status(400)
+                    .send(JSON.stringify({ error: 'Failed to delete task', details: (err as Error).message }))
             }
         }
     )

--- a/functions/src/api/routes/whatsapp/whatsapp.ts
+++ b/functions/src/api/routes/whatsapp/whatsapp.ts
@@ -1,31 +1,39 @@
 import { FastifyInstance } from 'fastify'
 import Type, { Static } from 'typebox'
 import { EventDao } from '../../dao/eventDao'
+import { GreenApiCreds, editMessage, sendInteractiveButtons, sendMessage, toChatId } from './greenApi'
+import { WhatsappSenders, handleTrackReady, startTrackSession } from './trackFlow'
+import { WhatsappSessionDao } from './whatsappSessionDao'
 
-// GreenAPI universal gateway. Each instance also has its own host (e.g. https://7105.api.greenapi.com),
-// but the shared gateway routes to the right instance from the id, so no per-event URL is needed.
-const GREEN_API_BASE = 'https://api.green-api.com'
-
-// A WhatsApp chatId for a person is the phone number (digits only, country code included) + "@c.us".
-const toChatId = (raw: string): string => {
-    const digits = raw.replace(/[^0-9]/g, '')
-    return `${digits}@c.us`
+const credsFromEvent = (event: {
+    greenApiInstanceId?: string | null
+    greenApiToken?: string | null
+}): GreenApiCreds | null => {
+    if (!event.greenApiInstanceId || !event.greenApiToken) return null
+    return { instanceId: event.greenApiInstanceId, token: event.greenApiToken }
 }
 
+// Bind the injected senders to a chat + creds so the flow code stays free of GreenAPI details.
+const sendersFor = (creds: GreenApiCreds): WhatsappSenders => ({
+    sendInteractiveButtons: (chatId, body, buttons) => sendInteractiveButtons(creds, chatId, body, buttons),
+    editMessage: (chatId, idMessage, message) => editMessage(creds, chatId, idMessage, message),
+    sendMessage: (chatId, message) => sendMessage(creds, chatId, message),
+})
+
 const SendBody = Type.Object({
-    to: Type.String({ description: 'Recipient phone number, international format (digits, country code included)' }),
+    to: Type.String(),
     message: Type.String({ minLength: 1 }),
 })
 type SendBodyType = Static<typeof SendBody>
 
-const SendReply = Type.Object({
-    sent: Type.Boolean(),
-    idMessage: Type.Optional(Type.String()),
+const StartBody = Type.Object({
+    chatId: Type.String({ description: 'Shared chat that receives the track buttons (phone or group chatId)' }),
 })
-type SendReplyType = Static<typeof SendReply>
+type StartBodyType = Static<typeof StartBody>
 
 export const whatsappRoutes = (fastify: FastifyInstance, options: any, done: () => any) => {
-    fastify.post<{ Params: { eventId: string }; Body: SendBodyType; Reply: SendReplyType | string }>(
+    // --- Test send: a single plain message to validate the GreenAPI setup ---
+    fastify.post<{ Params: { eventId: string }; Body: SendBodyType }>(
         '/v1/:eventId/whatsapp/send-test',
         {
             schema: {
@@ -34,7 +42,46 @@ export const whatsappRoutes = (fastify: FastifyInstance, options: any, done: () 
                 params: Type.Object({ eventId: Type.String() }),
                 body: SendBody,
                 response: {
-                    200: SendReply,
+                    200: Type.Object({ sent: Type.Boolean(), idMessage: Type.Optional(Type.String()) }),
+                    400: Type.String(),
+                    401: Type.String(),
+                },
+                security: [{ apiKey: [] }],
+            },
+            preHandler: fastify.auth([fastify.verifyApiKey]),
+        },
+        async (request, reply) => {
+            const event = await EventDao.getEvent(fastify.firebase, request.params.eventId)
+            const creds = credsFromEvent(event)
+            if (!creds) {
+                reply.status(400).send(JSON.stringify({ error: 'GreenAPI is not configured for this event.' }))
+                return
+            }
+            const { to, message } = request.body
+            if (!to || to.replace(/[^0-9]/g, '').length < 6) {
+                reply.status(400).send(JSON.stringify({ error: 'A valid recipient phone number is required.' }))
+                return
+            }
+            try {
+                const idMessage = await sendMessage(creds, toChatId(to), message)
+                reply.status(200).send({ sent: true, idMessage })
+            } catch (err) {
+                reply.status(400).send(JSON.stringify({ error: 'Failed to send', details: (err as Error).message }))
+            }
+        }
+    )
+
+    // --- Start track management: send chunked interactive button messages to the shared chat ---
+    fastify.post<{ Params: { eventId: string }; Body: StartBodyType }>(
+        '/v1/:eventId/whatsapp/track-management/start',
+        {
+            schema: {
+                tags: ['whatsapp'],
+                summary: 'Send the per-track "ready?" interactive buttons (max 3 per message) to the shared chat.',
+                params: Type.Object({ eventId: Type.String() }),
+                body: StartBody,
+                response: {
+                    200: Type.Object({ started: Type.Boolean(), trackCount: Type.Number() }),
                     400: Type.String(),
                     401: Type.String(),
                 },
@@ -44,55 +91,78 @@ export const whatsappRoutes = (fastify: FastifyInstance, options: any, done: () 
         },
         async (request, reply) => {
             const { eventId } = request.params
-            const { to, message } = request.body
-
             const event = await EventDao.getEvent(fastify.firebase, eventId)
-
-            const instanceId = event.greenApiInstanceId
-            const token = event.greenApiToken
-            if (!instanceId || !token) {
-                reply.status(400).send(
-                    JSON.stringify({
-                        error: 'GreenAPI is not configured for this event. Set the instance id and token first.',
-                    })
-                )
+            const creds = credsFromEvent(event)
+            if (!creds) {
+                reply.status(400).send(JSON.stringify({ error: 'GreenAPI is not configured for this event.' }))
                 return
             }
-
-            if (!to || to.replace(/[^0-9]/g, '').length < 6) {
-                reply.status(400).send(JSON.stringify({ error: 'A valid recipient phone number is required.' }))
+            const tracks = event.tracks || []
+            if (tracks.length === 0) {
+                reply.status(400).send(JSON.stringify({ error: 'This event has no tracks.' }))
                 return
             }
-
-            const url = `${GREEN_API_BASE}/waInstance${instanceId}/sendMessage/${token}`
-
+            const chatId = toChatId(request.body.chatId)
             try {
-                const res = await fetch(url, {
-                    method: 'POST',
-                    headers: { 'Content-Type': 'application/json' },
-                    body: JSON.stringify({ chatId: toChatId(to), message }),
-                })
-
-                const text = await res.text()
-                if (!res.ok) {
-                    reply.status(400).send(
-                        JSON.stringify({
-                            error: 'GreenAPI rejected the request',
-                            status: res.status,
-                            details: text,
-                        })
-                    )
-                    return
-                }
-
-                const data = text ? (JSON.parse(text) as { idMessage?: string }) : {}
-                reply.status(200).send({ sent: true, idMessage: data.idMessage })
+                const session = await startTrackSession(tracks, chatId, sendersFor(creds))
+                await WhatsappSessionDao.saveSession(fastify.firebase, eventId, session)
+                reply.status(200).send({ started: true, trackCount: tracks.length })
             } catch (err) {
-                const error = err as Error
-                reply.status(400).send(JSON.stringify({ error: 'Failed to reach GreenAPI', details: error.message }))
+                reply.status(400).send(JSON.stringify({ error: 'Failed to start', details: (err as Error).message }))
             }
         }
     )
+
+    // --- Status: current readiness, polled by the admin page ---
+    fastify.get<{ Params: { eventId: string } }>(
+        '/v1/:eventId/whatsapp/track-management/status',
+        {
+            schema: {
+                tags: ['whatsapp'],
+                summary: 'Current track-management readiness for the event.',
+                params: Type.Object({ eventId: Type.String() }),
+                response: { 200: Type.Any(), 401: Type.String() },
+                security: [{ apiKey: [] }],
+            },
+            preHandler: fastify.auth([fastify.verifyApiKey]),
+        },
+        async (request, reply) => {
+            const session = await WhatsappSessionDao.getSession(fastify.firebase, request.params.eventId)
+            reply.status(200).send(session || { chatId: null, tracks: [], messages: [], goSent: false })
+        }
+    )
+
+    // --- GreenAPI incoming webhook (global, no eventId; mapped via instance id). No apiKey: GreenAPI
+    //     calls it. It only acts on a button reply that matches a known event + session. ---
+    fastify.post('/v1/whatsapp/webhook', async (request, reply) => {
+        const body = (request.body || {}) as any
+
+        // Always 200 quickly so GreenAPI does not retry; do the work but never surface internals.
+        try {
+            const instanceId = body?.instanceData?.idInstance
+            const selectedButtonId =
+                body?.messageData?.interactiveButtonsReply?.buttonId ||
+                body?.messageData?.interactiveButtonsReply?.selectedButtonId ||
+                body?.messageData?.buttonsResponseMessage?.selectedButtonId ||
+                body?.messageData?.templateButtonReplyMessage?.selectedId
+
+            if (instanceId && selectedButtonId) {
+                const found = await WhatsappSessionDao.findEventByInstanceId(fastify.firebase, String(instanceId))
+                const creds = found && credsFromEvent(found.event)
+                if (found && creds) {
+                    const session = await WhatsappSessionDao.getSession(fastify.firebase, found.id)
+                    if (session) {
+                        const updated = await handleTrackReady(session, String(selectedButtonId), sendersFor(creds))
+                        await WhatsappSessionDao.saveSession(fastify.firebase, found.id, updated)
+                    }
+                }
+            }
+        } catch (err) {
+            request.log?.error({ err }, 'whatsapp webhook failed')
+        }
+
+        reply.status(200).send({ received: true })
+    })
 
     done()
 }

--- a/functions/src/api/routes/whatsapp/whatsapp.ts
+++ b/functions/src/api/routes/whatsapp/whatsapp.ts
@@ -375,10 +375,11 @@ export const whatsappRoutes = (fastify: FastifyInstance, options: any, done: () 
         try {
             const md = body?.messageData
             const votes: any[] = md?.pollMessageData?.votes || []
-            const votedOptionNames = votes
-                .filter((v) => (v?.optionVoters?.length || 0) > 0)
-                .map((v) => v?.optionName)
-                .filter(Boolean)
+            // Full snapshot of this poll's options: ready iff it currently has at least one voter.
+            const optionStates = votes
+                .map((v) => ({ name: v?.optionName as string, ready: (v?.optionVoters?.length || 0) > 0 }))
+                .filter((o) => o.name)
+            const votedOptionNames = optionStates.filter((o) => o.ready).map((o) => o.name)
 
             request.log?.info(
                 {
@@ -398,8 +399,10 @@ export const whatsappRoutes = (fastify: FastifyInstance, options: any, done: () 
                     return
                 }
                 const session = await WhatsappSessionDao.getSession(fastify.firebase, eventId)
-                if (session && votedOptionNames.length > 0) {
-                    const updated = applyPollVotes(session, votedOptionNames)
+                // Apply whenever the poll carries options (even with zero voters) so cancelling the last
+                // vote un-readies the track.
+                if (session && optionStates.length > 0) {
+                    const updated = applyPollVotes(session, optionStates)
                     await WhatsappSessionDao.saveSession(fastify.firebase, eventId, updated)
                 }
             }

--- a/functions/src/api/routes/whatsapp/whatsapp.ts
+++ b/functions/src/api/routes/whatsapp/whatsapp.ts
@@ -31,6 +31,14 @@ const StartBody = Type.Object({
 })
 type StartBodyType = Static<typeof StartBody>
 
+// Explicit reply schema: a bare Type.Any() makes fast-json-stringify drop every field (returns {}).
+const StatusReply = Type.Object({
+    chatId: Type.Union([Type.String(), Type.Null()]),
+    tracks: Type.Array(Type.Object({ id: Type.String(), name: Type.String(), ready: Type.Boolean() })),
+    messages: Type.Array(Type.Object({ idMessage: Type.String(), trackIds: Type.Array(Type.String()) })),
+    goSent: Type.Boolean(),
+})
+
 export const whatsappRoutes = (fastify: FastifyInstance, options: any, done: () => any) => {
     // --- Test send: a single plain message to validate the GreenAPI setup ---
     fastify.post<{ Params: { eventId: string }; Body: SendBodyType }>(
@@ -160,7 +168,7 @@ export const whatsappRoutes = (fastify: FastifyInstance, options: any, done: () 
                 tags: ['whatsapp'],
                 summary: 'Current track-management readiness for the event.',
                 params: Type.Object({ eventId: Type.String() }),
-                response: { 200: Type.Any(), 401: Type.String() },
+                response: { 200: StatusReply, 401: Type.String() },
                 security: [{ apiKey: [] }],
             },
             preHandler: fastify.auth([fastify.verifyApiKey]),

--- a/functions/src/api/routes/whatsapp/whatsappPanelTask.ts
+++ b/functions/src/api/routes/whatsapp/whatsappPanelTask.ts
@@ -37,5 +37,6 @@ export const sendWhatsappPanel = onTaskDispatched<PanelTaskPayload>(
         if (!session?.chatId) return
 
         await sendMessage(creds, session.chatId, message)
+        await WhatsappSessionDao.addPanelSent(app, eventId, message)
     }
 )

--- a/functions/src/api/routes/whatsapp/whatsappPanelTask.ts
+++ b/functions/src/api/routes/whatsapp/whatsappPanelTask.ts
@@ -1,0 +1,41 @@
+import { onTaskDispatched } from 'firebase-functions/v2/tasks'
+import fb, { credential } from 'firebase-admin'
+import { EventDao } from '../../dao/eventDao'
+import { credsFromEvent, sendMessage } from './greenApi'
+import { WhatsappSessionDao } from './whatsappSessionDao'
+
+export type PanelTaskPayload = { eventId: string; message: string }
+
+// Resource name used to enqueue tasks onto this queue; the region must match where it's deployed.
+export const sendWhatsappPanelTaskName = 'locations/europe-west1/functions/sendWhatsappPanel'
+
+// Task-dispatched functions run outside the Fastify app (which owns its own firebase-admin App via
+// its plugin), so get-or-create the default App here instead.
+const firebaseApp = (): fb.app.App => {
+    if (fb.apps.length > 0) return fb.apps[0] as fb.app.App
+    const cert = process.env.FIREBASE_SERVICE_ACCOUNT
+        ? JSON.parse(process.env.FIREBASE_SERVICE_ACCOUNT as string)
+        : undefined
+    return fb.initializeApp({
+        credential: cert ? credential.cert(cert) : fb.credential.applicationDefault(),
+    })
+}
+
+// Sends one scheduled timing reminder. Re-reads the session at execution time so a stale or
+// cleared session (e.g. a new track-management run started since) silently skips the send.
+export const sendWhatsappPanel = onTaskDispatched<PanelTaskPayload>(
+    { region: 'europe-west1', retryConfig: { maxAttempts: 3 }, rateLimits: { maxConcurrentDispatches: 5 } },
+    async (request) => {
+        const { eventId, message } = request.data
+        const app = firebaseApp()
+
+        const event = await EventDao.getEvent(app, eventId)
+        const creds = credsFromEvent(event)
+        if (!creds) return
+
+        const session = await WhatsappSessionDao.getSession(app, eventId)
+        if (!session?.chatId) return
+
+        await sendMessage(creds, session.chatId, message)
+    }
+)

--- a/functions/src/api/routes/whatsapp/whatsappSessionDao.ts
+++ b/functions/src/api/routes/whatsapp/whatsappSessionDao.ts
@@ -1,5 +1,4 @@
 import firebase from 'firebase-admin'
-import { Event } from '../../../types'
 import { TrackSession } from './trackSession'
 
 const SESSION_DOC = 'current'
@@ -15,22 +14,5 @@ export const WhatsappSessionDao = {
 
     async saveSession(firebaseApp: firebase.app.App, eventId: string, session: TrackSession): Promise<void> {
         await sessionRef(firebaseApp, eventId).set(session)
-    },
-
-    // GreenAPI's incoming webhook is global per instance and carries no eventId, so map the instance
-    // id back to its event.
-    async findEventByInstanceId(
-        firebaseApp: firebase.app.App,
-        instanceId: string
-    ): Promise<{ id: string; event: Event } | null> {
-        const query = await firebaseApp
-            .firestore()
-            .collection('events')
-            .where('greenApiInstanceId', '==', instanceId)
-            .limit(1)
-            .get()
-        if (query.empty) return null
-        const doc = query.docs[0]
-        return { id: doc.id, event: { ...(doc.data() as Event), id: doc.id } }
     },
 }

--- a/functions/src/api/routes/whatsapp/whatsappSessionDao.ts
+++ b/functions/src/api/routes/whatsapp/whatsappSessionDao.ts
@@ -1,6 +1,7 @@
 import firebase from 'firebase-admin'
 import { TrackSession } from './trackSession'
 
+const { FieldValue } = firebase.firestore
 const SESSION_DOC = 'current'
 
 const sessionRef = (firebaseApp: firebase.app.App, eventId: string) =>
@@ -14,5 +15,11 @@ export const WhatsappSessionDao = {
 
     async saveSession(firebaseApp: firebase.app.App, eventId: string, session: TrackSession): Promise<void> {
         await sessionRef(firebaseApp, eventId).set(session)
+    },
+
+    // Atomic field update (rather than read-modify-write the whole session) so a scheduled panel
+    // task recording its own send can't race with concurrent poll-vote/GO writes to the same doc.
+    async addPanelSent(firebaseApp: firebase.app.App, eventId: string, message: string): Promise<void> {
+        await sessionRef(firebaseApp, eventId).update({ panelsSent: FieldValue.arrayUnion(message) })
     },
 }

--- a/functions/src/api/routes/whatsapp/whatsappSessionDao.ts
+++ b/functions/src/api/routes/whatsapp/whatsappSessionDao.ts
@@ -1,0 +1,36 @@
+import firebase from 'firebase-admin'
+import { Event } from '../../../types'
+import { TrackSession } from './trackSession'
+
+const SESSION_DOC = 'current'
+
+const sessionRef = (firebaseApp: firebase.app.App, eventId: string) =>
+    firebaseApp.firestore().collection('events').doc(eventId).collection('whatsapp').doc(SESSION_DOC)
+
+export const WhatsappSessionDao = {
+    async getSession(firebaseApp: firebase.app.App, eventId: string): Promise<TrackSession | null> {
+        const snap = await sessionRef(firebaseApp, eventId).get()
+        return snap.exists ? (snap.data() as TrackSession) : null
+    },
+
+    async saveSession(firebaseApp: firebase.app.App, eventId: string, session: TrackSession): Promise<void> {
+        await sessionRef(firebaseApp, eventId).set(session)
+    },
+
+    // GreenAPI's incoming webhook is global per instance and carries no eventId, so map the instance
+    // id back to its event.
+    async findEventByInstanceId(
+        firebaseApp: firebase.app.App,
+        instanceId: string
+    ): Promise<{ id: string; event: Event } | null> {
+        const query = await firebaseApp
+            .firestore()
+            .collection('events')
+            .where('greenApiInstanceId', '==', instanceId)
+            .limit(1)
+            .get()
+        if (query.empty) return null
+        const doc = query.docs[0]
+        return { id: doc.id, event: { ...(doc.data() as Event), id: doc.id } }
+    },
+}

--- a/functions/src/api/setupFastify.ts
+++ b/functions/src/api/setupFastify.ts
@@ -13,6 +13,7 @@ import { sessionsRoutes } from './routes/sessions/sessions'
 import { faqRoutes } from './routes/faq/faq'
 import { transcriptionRoutes } from './routes/transcription/transcription'
 import { intermissionRoutes } from './routes/intermission/intermission'
+import { whatsappRoutes } from './routes/whatsapp/whatsapp'
 import { filesRoutes } from './routes/file/files'
 import { sessionsSpeakers } from './routes/sessionsSpeakers/sessionsSpeakers'
 import { speakersRoutes } from './routes/speakers/speakers'
@@ -68,6 +69,7 @@ export const setupFastify = () => {
     fastify.register(faqRoutes)
     fastify.register(transcriptionRoutes)
     fastify.register(intermissionRoutes)
+    fastify.register(whatsappRoutes)
     fastify.register(filesRoutes)
     fastify.register(deployRoutes)
     fastify.register(deployFilesRoutes)

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -1,4 +1,5 @@
 import { fastifyFunction } from './api'
 import { serviceApi } from './serviceApi/serviceApi'
+import { sendWhatsappPanel } from './api/routes/whatsapp/whatsappPanelTask'
 
-export { fastifyFunction as api, serviceApi }
+export { fastifyFunction as api, serviceApi, sendWhatsappPanel }

--- a/src/events/page/EventApp.tsx
+++ b/src/events/page/EventApp.tsx
@@ -22,6 +22,9 @@ const EventAPI = lazyWithRetry(() => import('./api/Api').then((module) => ({ def
 const EventPublic = lazyWithRetry(() =>
     import('./public/EventPublic').then((module) => ({ default: module.EventPublic }))
 )
+const EventWhatsApp = lazyWithRetry(() =>
+    import('./whatsapp/EventWhatsApp').then((module) => ({ default: module.EventWhatsApp }))
+)
 const EventSchedule = lazyWithRetry(() =>
     import('./schedule/EventSchedule').then((module) => ({ default: module.EventSchedule }))
 )
@@ -168,6 +171,11 @@ export const EventApp = ({ eventId }: { eventId?: string }) => {
                 <Route path="/public">
                     <Suspense fallback={<SuspenseLoader />}>
                         <EventPublic event={eventData} />
+                    </Suspense>
+                </Route>
+                <Route path="/whatsapp">
+                    <Suspense fallback={<SuspenseLoader />}>
+                        <EventWhatsApp event={eventData} />
                     </Suspense>
                 </Route>
                 <Route path="/social">

--- a/src/events/page/api/Api.tsx
+++ b/src/events/page/api/Api.tsx
@@ -5,8 +5,9 @@ import { useFirestoreDocumentMutation } from '../../../services/hooks/firestoreM
 import { doc } from 'firebase/firestore'
 import { collections } from '../../../services/firebase'
 import { FormContainer, useForm } from 'react-hook-form-mui'
-import { Card, Container, Grid, Typography, Box, IconButton, Collapse } from '@mui/material'
+import { Card, Container, Grid, Typography, Box, IconButton, Collapse, Button } from '@mui/material'
 import { ExpandMore as ExpandMoreIcon } from '@mui/icons-material'
+import { Link } from 'wouter'
 import { yupResolver } from '@hookform/resolvers/yup'
 import { mapEventDevSettingsFormToMutateObject } from '../settings/mapEventSettingsFormToMutateObject'
 import { WebhooksFields } from '../settings/components/WebhooksFields'
@@ -121,6 +122,20 @@ export const API = ({ event }: APIProps) => {
                             buttonText="Generate new API Key"
                         />
                     </Collapse>
+                </Card>
+
+                <Card sx={{ paddingX: 2, mt: 4 }}>
+                    <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', py: 2 }}>
+                        <Box>
+                            <Typography fontSize="large">WhatsApp (track management)</Typography>
+                            <Typography variant="body2" color="text.secondary">
+                                Set up GreenAPI and send track-management messages.
+                            </Typography>
+                        </Box>
+                        <Button component={Link} to="/whatsapp" variant="outlined">
+                            Open
+                        </Button>
+                    </Box>
                 </Card>
 
                 <Card sx={{ paddingX: 2, mt: 4 }}>

--- a/src/events/page/layouts/EventLayout.tsx
+++ b/src/events/page/layouts/EventLayout.tsx
@@ -134,7 +134,8 @@ export const EventLayout = ({ children, event, customTitle }: EventLayoutProps) 
         return `/${firstParams?.routeName}`.startsWith(item.href) || `/${subParams?.routeName}`.startsWith(item.href)
     })
     const routeName = menuItem ? menuItem.name : 'Loading...'
-    const hideAppBar = menuItem?.href === '/schedule'
+    // WhatsApp isn't in the sidebar Menu, so match its route param directly (it has its own header).
+    const hideAppBar = menuItem?.href === '/schedule' || firstParams?.routeName === 'whatsapp'
 
     return (
         <PortalContext.Provider value={{ rightToolbarElement, titleElement }}>

--- a/src/events/page/settings/mapEventSettingsFormToMutateObject.ts
+++ b/src/events/page/settings/mapEventSettingsFormToMutateObject.ts
@@ -105,5 +105,9 @@ export const mapEventDevSettingsFormToMutateObject = (event: Event, data: EventS
         greenApiInstanceId:
             data.greenApiInstanceId !== undefined ? data.greenApiInstanceId || null : event.greenApiInstanceId ?? null,
         greenApiToken: data.greenApiToken !== undefined ? data.greenApiToken || null : event.greenApiToken ?? null,
+        whatsappSharedChatId:
+            data.whatsappSharedChatId !== undefined
+                ? data.whatsappSharedChatId || null
+                : event.whatsappSharedChatId ?? null,
     }
 }

--- a/src/events/page/settings/mapEventSettingsFormToMutateObject.ts
+++ b/src/events/page/settings/mapEventSettingsFormToMutateObject.ts
@@ -102,5 +102,8 @@ export const mapEventDevSettingsFormToMutateObject = (event: Event, data: EventS
             data.transcriptionPassword !== undefined
                 ? data.transcriptionPassword || ''
                 : event.transcriptionPassword ?? '',
+        greenApiInstanceId:
+            data.greenApiInstanceId !== undefined ? data.greenApiInstanceId || null : event.greenApiInstanceId ?? null,
+        greenApiToken: data.greenApiToken !== undefined ? data.greenApiToken || null : event.greenApiToken ?? null,
     }
 }

--- a/src/events/page/whatsapp/EventWhatsApp.tsx
+++ b/src/events/page/whatsapp/EventWhatsApp.tsx
@@ -13,6 +13,7 @@ import { TextFieldElementPrivate } from '../../../components/form/TextFieldEleme
 import { SaveShortcut } from '../../../components/form/SaveShortcut'
 import { fetchOpenPlannerApi } from '../../../services/hooks/useOpenPlannerApi'
 import { useNotification } from '../../../hooks/notificationHook'
+import { TrackManagementSection } from './TrackManagementSection'
 
 const schema = yup
     .object({
@@ -125,6 +126,8 @@ export const EventWhatsApp = ({ event }: EventWhatsAppProps) => {
                     <SaveShortcut />
                 </FormContainer>
             </Card>
+
+            {isConfigured && <TrackManagementSection event={event} />}
 
             <Card sx={{ paddingX: 2, mt: 4, mb: 2 }}>
                 <Typography fontSize="large" sx={{ mt: 2, mb: 1 }}>

--- a/src/events/page/whatsapp/EventWhatsApp.tsx
+++ b/src/events/page/whatsapp/EventWhatsApp.tsx
@@ -1,178 +1,49 @@
-import * as yup from 'yup'
-import { useEffect, useState } from 'react'
-import { doc } from 'firebase/firestore'
-import { FormContainer, useForm, TextFieldElement } from 'react-hook-form-mui'
-import { Box, Card, Container, Grid, TextField, Typography } from '@mui/material'
-import { yupResolver } from '@hookform/resolvers/yup'
-import LoadingButton from '@mui/lab/LoadingButton'
-import { Event, EventSettingForForm } from '../../../types'
-import { collections } from '../../../services/firebase'
-import { useFirestoreDocumentMutation } from '../../../services/hooks/firestoreMutationHooks'
-import { mapEventDevSettingsFormToMutateObject } from '../settings/mapEventSettingsFormToMutateObject'
-import { TextFieldElementPrivate } from '../../../components/form/TextFieldElementPrivate'
-import { SaveShortcut } from '../../../components/form/SaveShortcut'
-import { fetchOpenPlannerApi } from '../../../services/hooks/useOpenPlannerApi'
-import { useNotification } from '../../../hooks/notificationHook'
+import { useState } from 'react'
+import { Box, Button, Card, Container, Stack, Typography } from '@mui/material'
+import { Settings as SettingsIcon } from '@mui/icons-material'
+import { Event } from '../../../types'
 import { TrackManagementSection } from './TrackManagementSection'
-
-const schema = yup
-    .object({
-        greenApiInstanceId: yup.string().nullable(),
-        greenApiToken: yup.string().nullable(),
-    })
-    .required()
-
-// Carry the full settings shape (not just the GreenAPI fields): mapEventDevSettingsFormToMutateObject
-// reads webhooks/apiKey/publicEnabled/repoUrl from the submitted data, so omitting them would wipe them.
-const convertInputEvent = (event: Event): EventSettingForForm => ({
-    ...event,
-    webhooks: event.webhooks || [],
-    apiKey: event.apiKey,
-    publicEnabled: event.publicEnabled || false,
-    repoUrl: event.repoUrl || null,
-    repoToken: event.repoToken || null,
-    greenApiInstanceId: event.greenApiInstanceId || '',
-    greenApiToken: event.greenApiToken || '',
-})
+import { WhatsAppConfigModal } from './WhatsAppConfigModal'
 
 export type EventWhatsAppProps = {
     event: Event
 }
 
 export const EventWhatsApp = ({ event }: EventWhatsAppProps) => {
-    const mutation = useFirestoreDocumentMutation(doc(collections.events, event.id))
-    const { createNotification } = useNotification()
-
-    const formContext = useForm({ defaultValues: convertInputEvent(event) })
-    const { formState, reset } = formContext
-
-    useEffect(() => {
-        reset(convertInputEvent(event))
-    }, [event])
-
     const isConfigured = Boolean(event.greenApiInstanceId && event.greenApiToken)
 
-    const [to, setTo] = useState('')
-    const [message, setMessage] = useState('Test message from OpenPlanner ✅')
-    const [sending, setSending] = useState(false)
-
-    const sendTest = async () => {
-        setSending(true)
-        try {
-            await fetchOpenPlannerApi(event, 'whatsapp/send-test', {
-                method: 'POST',
-                body: { to, message },
-            })
-            createNotification('WhatsApp message sent', { type: 'success' })
-        } catch (error) {
-            createNotification('Failed to send: ' + (error instanceof Error ? error.message : 'Unknown error'), {
-                type: 'error',
-            })
-        } finally {
-            setSending(false)
-        }
-    }
+    // Open the config modal straight away on first setup so the operator can't miss it.
+    const [configOpen, setConfigOpen] = useState(!isConfigured)
 
     return (
         <Container maxWidth="lg" sx={{ mt: 4, mb: 4 }}>
-            <Typography component="h1" variant="h5">
-                WhatsApp (track management)
-            </Typography>
-
-            <Card sx={{ paddingX: 2, mt: 2 }}>
-                <FormContainer
-                    formContext={formContext}
-                    // @ts-ignore
-                    resolver={yupResolver(schema)}
-                    onSuccess={async (data) => mutation.mutate(mapEventDevSettingsFormToMutateObject(event, data))}>
-                    <Typography fontSize="large" sx={{ mt: 2, mb: 1 }}>
-                        GreenAPI credentials
-                    </Typography>
-                    <Typography variant="body2" color="text.secondary" mb={2}>
-                        Create an instance on{' '}
-                        <a href="https://green-api.com" target="_blank" rel="noreferrer">
-                            green-api.com
-                        </a>{' '}
-                        and paste its instance id and API token. Messages are sent server-side, so the token never
-                        leaves the backend.
-                    </Typography>
-                    <TextFieldElement
-                        margin="normal"
-                        fullWidth
-                        id="greenApiInstanceId"
-                        label="GreenAPI instance id"
-                        name="greenApiInstanceId"
-                        helperText="e.g. 7105xxxxxx"
-                    />
-                    <TextFieldElementPrivate
-                        margin="normal"
-                        fullWidth
-                        id="greenApiToken"
-                        label="GreenAPI API token"
-                        name="greenApiToken"
-                        variant="filled"
-                    />
-                    <Grid item xs={12}>
-                        <LoadingButton
-                            type="submit"
-                            disabled={formState.isSubmitting}
-                            loading={formState.isSubmitting}
-                            fullWidth
-                            variant="contained"
-                            sx={{ mt: 2, mb: 2 }}>
-                            Save
-                        </LoadingButton>
-                    </Grid>
-                    <SaveShortcut />
-                </FormContainer>
-            </Card>
-
-            {isConfigured && <TrackManagementSection event={event} />}
-
-            <Card sx={{ paddingX: 2, mt: 4, mb: 2 }}>
-                <Typography fontSize="large" sx={{ mt: 2, mb: 1 }}>
-                    Send a test message
+            <Stack direction="row" justifyContent="space-between" alignItems="center" mb={2}>
+                <Typography component="h1" variant="h5">
+                    WhatsApp (track management)
                 </Typography>
-                {isConfigured ? (
-                    <Box>
-                        <Typography variant="body2" color="text.secondary" mb={2}>
-                            Send one WhatsApp message to check the setup. Use the international format (country code
-                            included), e.g. <code>+33612345678</code>.
-                        </Typography>
-                        <TextField
-                            margin="normal"
-                            fullWidth
-                            label="Recipient phone number"
-                            value={to}
-                            onChange={(e) => setTo(e.target.value)}
-                            placeholder="+33612345678"
-                        />
-                        <TextField
-                            margin="normal"
-                            fullWidth
-                            multiline
-                            minRows={2}
-                            label="Message"
-                            value={message}
-                            onChange={(e) => setMessage(e.target.value)}
-                        />
-                        <Grid item xs={12}>
-                            <LoadingButton
-                                onClick={sendTest}
-                                disabled={sending || to.trim().length === 0 || message.trim().length === 0}
-                                loading={sending}
-                                variant="contained"
-                                sx={{ mt: 2, mb: 2 }}>
-                                Send test message
-                            </LoadingButton>
-                        </Grid>
-                    </Box>
-                ) : (
-                    <Typography variant="body2" color="text.secondary" sx={{ py: 2 }}>
-                        Save your GreenAPI instance id and token above to unlock sending.
+                <Button variant="outlined" startIcon={<SettingsIcon />} onClick={() => setConfigOpen(true)}>
+                    Configuration
+                </Button>
+            </Stack>
+
+            {isConfigured ? (
+                <TrackManagementSection event={event} />
+            ) : (
+                <Card sx={{ p: 2 }}>
+                    <Typography variant="body2" color="text.secondary">
+                        WhatsApp isn't configured yet. Add your GreenAPI credentials and shared chat in the{' '}
+                        <Box
+                            component="span"
+                            sx={{ cursor: 'pointer', textDecoration: 'underline' }}
+                            onClick={() => setConfigOpen(true)}>
+                            configuration
+                        </Box>{' '}
+                        to start managing tracks.
                     </Typography>
-                )}
-            </Card>
+                </Card>
+            )}
+
+            <WhatsAppConfigModal open={configOpen} onClose={() => setConfigOpen(false)} event={event} />
         </Container>
     )
 }

--- a/src/events/page/whatsapp/EventWhatsApp.tsx
+++ b/src/events/page/whatsapp/EventWhatsApp.tsx
@@ -1,0 +1,175 @@
+import * as yup from 'yup'
+import { useEffect, useState } from 'react'
+import { doc } from 'firebase/firestore'
+import { FormContainer, useForm, TextFieldElement } from 'react-hook-form-mui'
+import { Box, Card, Container, Grid, TextField, Typography } from '@mui/material'
+import { yupResolver } from '@hookform/resolvers/yup'
+import LoadingButton from '@mui/lab/LoadingButton'
+import { Event, EventSettingForForm } from '../../../types'
+import { collections } from '../../../services/firebase'
+import { useFirestoreDocumentMutation } from '../../../services/hooks/firestoreMutationHooks'
+import { mapEventDevSettingsFormToMutateObject } from '../settings/mapEventSettingsFormToMutateObject'
+import { TextFieldElementPrivate } from '../../../components/form/TextFieldElementPrivate'
+import { SaveShortcut } from '../../../components/form/SaveShortcut'
+import { fetchOpenPlannerApi } from '../../../services/hooks/useOpenPlannerApi'
+import { useNotification } from '../../../hooks/notificationHook'
+
+const schema = yup
+    .object({
+        greenApiInstanceId: yup.string().nullable(),
+        greenApiToken: yup.string().nullable(),
+    })
+    .required()
+
+// Carry the full settings shape (not just the GreenAPI fields): mapEventDevSettingsFormToMutateObject
+// reads webhooks/apiKey/publicEnabled/repoUrl from the submitted data, so omitting them would wipe them.
+const convertInputEvent = (event: Event): EventSettingForForm => ({
+    ...event,
+    webhooks: event.webhooks || [],
+    apiKey: event.apiKey,
+    publicEnabled: event.publicEnabled || false,
+    repoUrl: event.repoUrl || null,
+    repoToken: event.repoToken || null,
+    greenApiInstanceId: event.greenApiInstanceId || '',
+    greenApiToken: event.greenApiToken || '',
+})
+
+export type EventWhatsAppProps = {
+    event: Event
+}
+
+export const EventWhatsApp = ({ event }: EventWhatsAppProps) => {
+    const mutation = useFirestoreDocumentMutation(doc(collections.events, event.id))
+    const { createNotification } = useNotification()
+
+    const formContext = useForm({ defaultValues: convertInputEvent(event) })
+    const { formState, reset } = formContext
+
+    useEffect(() => {
+        reset(convertInputEvent(event))
+    }, [event])
+
+    const isConfigured = Boolean(event.greenApiInstanceId && event.greenApiToken)
+
+    const [to, setTo] = useState('')
+    const [message, setMessage] = useState('Test message from OpenPlanner ✅')
+    const [sending, setSending] = useState(false)
+
+    const sendTest = async () => {
+        setSending(true)
+        try {
+            await fetchOpenPlannerApi(event, 'whatsapp/send-test', {
+                method: 'POST',
+                body: { to, message },
+            })
+            createNotification('WhatsApp message sent', { type: 'success' })
+        } catch (error) {
+            createNotification('Failed to send: ' + (error instanceof Error ? error.message : 'Unknown error'), {
+                type: 'error',
+            })
+        } finally {
+            setSending(false)
+        }
+    }
+
+    return (
+        <Container maxWidth="lg" sx={{ mt: 4, mb: 4 }}>
+            <Typography component="h1" variant="h5">
+                WhatsApp (track management)
+            </Typography>
+
+            <Card sx={{ paddingX: 2, mt: 2 }}>
+                <FormContainer
+                    formContext={formContext}
+                    // @ts-ignore
+                    resolver={yupResolver(schema)}
+                    onSuccess={async (data) => mutation.mutate(mapEventDevSettingsFormToMutateObject(event, data))}>
+                    <Typography fontSize="large" sx={{ mt: 2, mb: 1 }}>
+                        GreenAPI credentials
+                    </Typography>
+                    <Typography variant="body2" color="text.secondary" mb={2}>
+                        Create an instance on{' '}
+                        <a href="https://green-api.com" target="_blank" rel="noreferrer">
+                            green-api.com
+                        </a>{' '}
+                        and paste its instance id and API token. Messages are sent server-side, so the token never
+                        leaves the backend.
+                    </Typography>
+                    <TextFieldElement
+                        margin="normal"
+                        fullWidth
+                        id="greenApiInstanceId"
+                        label="GreenAPI instance id"
+                        name="greenApiInstanceId"
+                        helperText="e.g. 7105xxxxxx"
+                    />
+                    <TextFieldElementPrivate
+                        margin="normal"
+                        fullWidth
+                        id="greenApiToken"
+                        label="GreenAPI API token"
+                        name="greenApiToken"
+                        variant="filled"
+                    />
+                    <Grid item xs={12}>
+                        <LoadingButton
+                            type="submit"
+                            disabled={formState.isSubmitting}
+                            loading={formState.isSubmitting}
+                            fullWidth
+                            variant="contained"
+                            sx={{ mt: 2, mb: 2 }}>
+                            Save
+                        </LoadingButton>
+                    </Grid>
+                    <SaveShortcut />
+                </FormContainer>
+            </Card>
+
+            <Card sx={{ paddingX: 2, mt: 4, mb: 2 }}>
+                <Typography fontSize="large" sx={{ mt: 2, mb: 1 }}>
+                    Send a test message
+                </Typography>
+                {isConfigured ? (
+                    <Box>
+                        <Typography variant="body2" color="text.secondary" mb={2}>
+                            Send one WhatsApp message to check the setup. Use the international format (country code
+                            included), e.g. <code>+33612345678</code>.
+                        </Typography>
+                        <TextField
+                            margin="normal"
+                            fullWidth
+                            label="Recipient phone number"
+                            value={to}
+                            onChange={(e) => setTo(e.target.value)}
+                            placeholder="+33612345678"
+                        />
+                        <TextField
+                            margin="normal"
+                            fullWidth
+                            multiline
+                            minRows={2}
+                            label="Message"
+                            value={message}
+                            onChange={(e) => setMessage(e.target.value)}
+                        />
+                        <Grid item xs={12}>
+                            <LoadingButton
+                                onClick={sendTest}
+                                disabled={sending || to.trim().length === 0 || message.trim().length === 0}
+                                loading={sending}
+                                variant="contained"
+                                sx={{ mt: 2, mb: 2 }}>
+                                Send test message
+                            </LoadingButton>
+                        </Grid>
+                    </Box>
+                ) : (
+                    <Typography variant="body2" color="text.secondary" sx={{ py: 2 }}>
+                        Save your GreenAPI instance id and token above to unlock sending.
+                    </Typography>
+                )}
+            </Card>
+        </Container>
+    )
+}

--- a/src/events/page/whatsapp/ScheduledRemindersList.tsx
+++ b/src/events/page/whatsapp/ScheduledRemindersList.tsx
@@ -1,0 +1,81 @@
+import { useCallback, useEffect, useState } from 'react'
+import { Box, IconButton, List, ListItem, ListItemText, Typography } from '@mui/material'
+import { Delete as DeleteIcon } from '@mui/icons-material'
+import { Event } from '../../../types'
+import { fetchOpenPlannerApi } from '../../../services/hooks/useOpenPlannerApi'
+import { useNotification } from '../../../hooks/notificationHook'
+
+type ScheduledTask = { name: string; scheduleTime: string | null; message: string }
+
+export type ScheduledRemindersListProps = {
+    event: Event
+    // Bump to force a refresh (e.g. when a reminder fires and the list should shrink).
+    refreshSignal?: number
+}
+
+// Lists the still-pending reminder tasks (Cloud Tasks) for the event and lets the operator cancel any.
+export const ScheduledRemindersList = ({ event, refreshSignal }: ScheduledRemindersListProps) => {
+    const { createNotification } = useNotification()
+    const [tasks, setTasks] = useState<ScheduledTask[]>([])
+    const [deleting, setDeleting] = useState<string | null>(null)
+
+    const refresh = useCallback(async () => {
+        try {
+            const res = await fetchOpenPlannerApi<{ tasks: ScheduledTask[] }>(event, 'whatsapp/scheduled-tasks', {
+                method: 'GET',
+            })
+            setTasks(res.tasks || [])
+        } catch {
+            // best-effort listing
+        }
+    }, [event])
+
+    useEffect(() => {
+        refresh()
+    }, [refresh, refreshSignal])
+
+    const remove = async (name: string) => {
+        setDeleting(name)
+        try {
+            await fetchOpenPlannerApi(event, 'whatsapp/scheduled-tasks', { method: 'DELETE', body: { name } })
+            createNotification('Reminder cancelled', { type: 'success' })
+            await refresh()
+        } catch (error) {
+            createNotification('Failed to cancel: ' + (error instanceof Error ? error.message : 'Unknown error'), {
+                type: 'error',
+            })
+        } finally {
+            setDeleting(null)
+        }
+    }
+
+    if (tasks.length === 0) return null
+
+    return (
+        <Box mt={2}>
+            <Typography variant="subtitle2" gutterBottom>
+                Scheduled reminders
+            </Typography>
+            <List dense disablePadding>
+                {tasks.map((task) => (
+                    <ListItem
+                        key={task.name}
+                        secondaryAction={
+                            <IconButton
+                                edge="end"
+                                aria-label="cancel reminder"
+                                disabled={deleting === task.name}
+                                onClick={() => remove(task.name)}>
+                                <DeleteIcon />
+                            </IconButton>
+                        }>
+                        <ListItemText
+                            primary={task.message}
+                            secondary={task.scheduleTime ? new Date(task.scheduleTime).toLocaleString() : 'pending'}
+                        />
+                    </ListItem>
+                ))}
+            </List>
+        </Box>
+    )
+}

--- a/src/events/page/whatsapp/TrackManagementSection.tsx
+++ b/src/events/page/whatsapp/TrackManagementSection.tsx
@@ -1,10 +1,12 @@
 import { useCallback, useEffect, useState } from 'react'
 import { Box, Card, Chip, Grid, Stack, TextField, Typography } from '@mui/material'
 import LoadingButton from '@mui/lab/LoadingButton'
+import { doc, updateDoc } from 'firebase/firestore'
 import { Event } from '../../../types'
 import { fetchOpenPlannerApi } from '../../../services/hooks/useOpenPlannerApi'
 import { useNotification } from '../../../hooks/notificationHook'
 import { TypographyCopyable } from '../../../components/TypographyCopyable'
+import { collections } from '../../../services/firebase'
 import { API_URL } from '../../../env'
 
 type TrackStatus = { id: string; name: string; ready: boolean }
@@ -19,9 +21,25 @@ const webhookUrl = `${String(API_URL ?? '').replace(/\/+$/, '')}/v1/whatsapp/web
 
 export const TrackManagementSection = ({ event }: { event: Event }) => {
     const { createNotification } = useNotification()
-    const [chatId, setChatId] = useState('')
+    // Seed from the saved event setting so the operator doesn't retype it.
+    const [chatId, setChatId] = useState(event.whatsappSharedChatId || '')
     const [starting, setStarting] = useState(false)
+    const [savingChat, setSavingChat] = useState(false)
     const [status, setStatus] = useState<SessionStatus | null>(null)
+
+    const saveSharedChat = async () => {
+        setSavingChat(true)
+        try {
+            await updateDoc(doc(collections.events, event.id), { whatsappSharedChatId: chatId.trim() || null })
+            createNotification('Shared chat saved', { type: 'success' })
+        } catch (error) {
+            createNotification('Failed to save chat: ' + (error instanceof Error ? error.message : 'Unknown error'), {
+                type: 'error',
+            })
+        } finally {
+            setSavingChat(false)
+        }
+    }
 
     const refresh = useCallback(async () => {
         try {
@@ -74,6 +92,8 @@ export const TrackManagementSection = ({ event }: { event: Event }) => {
                 method: 'POST',
                 body: { chatId },
             })
+            // Remember the chat for next time.
+            await updateDoc(doc(collections.events, event.id), { whatsappSharedChatId: chatId.trim() || null })
             createNotification('Track buttons sent', { type: 'success' })
             await refresh()
         } catch (error) {
@@ -109,16 +129,18 @@ export const TrackManagementSection = ({ event }: { event: Event }) => {
                 placeholder="120363xxxxxxxxxx@g.us"
                 helperText="A group chatId ends with @g.us, a single contact with @c.us. A raw phone number (international format) is sent to @c.us automatically."
             />
-            <Grid item xs={12}>
+            <Stack direction="row" spacing={1} sx={{ mt: 1, mb: 2 }}>
+                <LoadingButton onClick={saveSharedChat} disabled={savingChat} loading={savingChat} variant="outlined">
+                    Save chat
+                </LoadingButton>
                 <LoadingButton
                     onClick={start}
                     disabled={starting || chatId.trim().length === 0}
                     loading={starting}
-                    variant="contained"
-                    sx={{ mt: 1, mb: 2 }}>
+                    variant="contained">
                     Send track buttons
                 </LoadingButton>
-            </Grid>
+            </Stack>
 
             {total > 0 && (
                 <Box mb={2}>

--- a/src/events/page/whatsapp/TrackManagementSection.tsx
+++ b/src/events/page/whatsapp/TrackManagementSection.tsx
@@ -1,0 +1,122 @@
+import { useCallback, useEffect, useState } from 'react'
+import { Box, Card, Chip, Grid, Stack, TextField, Typography } from '@mui/material'
+import LoadingButton from '@mui/lab/LoadingButton'
+import { Event } from '../../../types'
+import { fetchOpenPlannerApi } from '../../../services/hooks/useOpenPlannerApi'
+import { useNotification } from '../../../hooks/notificationHook'
+import { TypographyCopyable } from '../../../components/TypographyCopyable'
+import { API_URL } from '../../../env'
+
+type TrackStatus = { id: string; name: string; ready: boolean }
+type SessionStatus = {
+    chatId: string | null
+    tracks: TrackStatus[]
+    goSent: boolean
+}
+
+const webhookUrl = `${API_URL}v1/whatsapp/webhook`
+
+export const TrackManagementSection = ({ event }: { event: Event }) => {
+    const { createNotification } = useNotification()
+    const [chatId, setChatId] = useState('')
+    const [starting, setStarting] = useState(false)
+    const [status, setStatus] = useState<SessionStatus | null>(null)
+
+    const refresh = useCallback(async () => {
+        try {
+            const s = await fetchOpenPlannerApi<SessionStatus>(event, 'whatsapp/track-management/status', {
+                method: 'GET',
+            })
+            setStatus(s)
+        } catch {
+            // status polling is best-effort
+        }
+    }, [event])
+
+    // Poll so button presses (handled via the GreenAPI webhook) show up without a manual reload.
+    useEffect(() => {
+        refresh()
+        const id = setInterval(refresh, 5000)
+        return () => clearInterval(id)
+    }, [refresh])
+
+    const start = async () => {
+        setStarting(true)
+        try {
+            await fetchOpenPlannerApi(event, 'whatsapp/track-management/start', {
+                method: 'POST',
+                body: { chatId },
+            })
+            createNotification('Track buttons sent', { type: 'success' })
+            await refresh()
+        } catch (error) {
+            createNotification('Failed to start: ' + (error instanceof Error ? error.message : 'Unknown error'), {
+                type: 'error',
+            })
+        } finally {
+            setStarting(false)
+        }
+    }
+
+    const readyCount = status?.tracks.filter((t) => t.ready).length ?? 0
+    const total = status?.tracks.length ?? 0
+
+    return (
+        <Card sx={{ paddingX: 2, mt: 4, mb: 2 }}>
+            <Typography fontSize="large" sx={{ mt: 2, mb: 1 }}>
+                Track management
+            </Typography>
+            <Typography variant="body2" color="text.secondary" mb={2}>
+                Send each track a "ready?" button (max 3 per WhatsApp message, split across messages). When a track
+                manager taps their button it is marked ready; once every track is ready, a GO message is sent to the
+                same chat.
+            </Typography>
+
+            <TextField
+                margin="normal"
+                fullWidth
+                label="Shared chat (phone number or group chatId)"
+                value={chatId}
+                onChange={(e) => setChatId(e.target.value)}
+                placeholder="+33612345678 or 1203630xxxxx@g.us"
+                helperText="Group of track managers, or a single ops number. International format for a phone."
+            />
+            <Grid item xs={12}>
+                <LoadingButton
+                    onClick={start}
+                    disabled={starting || chatId.trim().length === 0}
+                    loading={starting}
+                    variant="contained"
+                    sx={{ mt: 1, mb: 2 }}>
+                    Send track buttons
+                </LoadingButton>
+            </Grid>
+
+            {status && total > 0 && (
+                <Box mb={2}>
+                    <Typography variant="subtitle2" gutterBottom>
+                        Readiness {readyCount}/{total}
+                        {status.goSent ? ' — GO sent 🟢' : ''}
+                    </Typography>
+                    <Stack direction="row" spacing={1} flexWrap="wrap" useFlexGap>
+                        {status.tracks.map((t) => (
+                            <Chip
+                                key={t.id}
+                                label={t.name}
+                                color={t.ready ? 'success' : 'default'}
+                                variant={t.ready ? 'filled' : 'outlined'}
+                            />
+                        ))}
+                    </Stack>
+                </Box>
+            )}
+
+            <Box mt={2}>
+                <Typography variant="body2" gutterBottom>
+                    GreenAPI webhook URL (set it in your instance settings so button taps are received)
+                </Typography>
+                <TypographyCopyable singleLine={true}>{webhookUrl}</TypographyCopyable>
+            </Box>
+        </Card>
+    )
+}

--- a/src/events/page/whatsapp/TrackManagementSection.tsx
+++ b/src/events/page/whatsapp/TrackManagementSection.tsx
@@ -14,7 +14,8 @@ type SessionStatus = {
     goSent: boolean
 }
 
-const webhookUrl = `${API_URL}v1/whatsapp/webhook`
+// API_URL may or may not carry a trailing slash; normalise so the URL is always well-formed.
+const webhookUrl = `${String(API_URL ?? '').replace(/\/+$/, '')}/v1/whatsapp/webhook`
 
 export const TrackManagementSection = ({ event }: { event: Event }) => {
     const { createNotification } = useNotification()
@@ -76,11 +77,11 @@ export const TrackManagementSection = ({ event }: { event: Event }) => {
             <TextField
                 margin="normal"
                 fullWidth
-                label="Shared chat (phone number or group chatId)"
+                label="Shared chat (chatId ending with @c.us or @g.us)"
                 value={chatId}
                 onChange={(e) => setChatId(e.target.value)}
-                placeholder="+33612345678 or 1203630xxxxx@g.us"
-                helperText="Group of track managers, or a single ops number. International format for a phone."
+                placeholder="120363xxxxxxxxxx@g.us"
+                helperText="A group chatId ends with @g.us, a single contact with @c.us. A raw phone number (international format) is sent to @c.us automatically."
             />
             <Grid item xs={12}>
                 <LoadingButton

--- a/src/events/page/whatsapp/TrackManagementSection.tsx
+++ b/src/events/page/whatsapp/TrackManagementSection.tsx
@@ -58,8 +58,9 @@ export const TrackManagementSection = ({ event }: { event: Event }) => {
         }
     }
 
-    const readyCount = status?.tracks.filter((t) => t.ready).length ?? 0
-    const total = status?.tracks.length ?? 0
+    const trackList = status?.tracks ?? []
+    const readyCount = trackList.filter((t) => t.ready).length
+    const total = trackList.length
 
     return (
         <Card sx={{ paddingX: 2, mt: 4, mb: 2 }}>
@@ -92,14 +93,14 @@ export const TrackManagementSection = ({ event }: { event: Event }) => {
                 </LoadingButton>
             </Grid>
 
-            {status && total > 0 && (
+            {total > 0 && (
                 <Box mb={2}>
                     <Typography variant="subtitle2" gutterBottom>
                         Readiness {readyCount}/{total}
-                        {status.goSent ? ' — GO sent 🟢' : ''}
+                        {status?.goSent ? ' — GO sent 🟢' : ''}
                     </Typography>
                     <Stack direction="row" spacing={1} flexWrap="wrap" useFlexGap>
-                        {status.tracks.map((t) => (
+                        {trackList.map((t) => (
                             <Chip
                                 key={t.id}
                                 label={t.name}

--- a/src/events/page/whatsapp/TrackManagementSection.tsx
+++ b/src/events/page/whatsapp/TrackManagementSection.tsx
@@ -17,9 +17,11 @@ type SessionStatus = {
 }
 
 // API_URL may or may not carry a trailing slash; normalise so the URL is always well-formed.
-const webhookUrl = `${String(API_URL ?? '').replace(/\/+$/, '')}/v1/whatsapp/webhook`
+const apiBase = String(API_URL ?? '').replace(/\/+$/, '')
 
 export const TrackManagementSection = ({ event }: { event: Event }) => {
+    // Event-scoped webhook so GreenAPI posts straight to this event's endpoint.
+    const webhookUrl = `${apiBase}/v1/${event.id}/whatsapp/webhook`
     const { createNotification } = useNotification()
     // Seed from the saved event setting so the operator doesn't retype it.
     const [chatId, setChatId] = useState(event.whatsappSharedChatId || '')
@@ -115,9 +117,8 @@ export const TrackManagementSection = ({ event }: { event: Event }) => {
                 Track management
             </Typography>
             <Typography variant="body2" color="text.secondary" mb={2}>
-                Send each track a "ready?" button (max 3 per WhatsApp message, split across messages). When a track
-                manager taps their button it is marked ready; once every track is ready, a GO message is sent to the
-                same chat.
+                Send a WhatsApp poll listing the tracks (up to 12 options per poll). When a track manager taps their
+                track in the poll it is marked ready; once every track is ready, a GO message is sent to the same chat.
             </Typography>
 
             <TextField
@@ -138,7 +139,7 @@ export const TrackManagementSection = ({ event }: { event: Event }) => {
                     disabled={starting || chatId.trim().length === 0}
                     loading={starting}
                     variant="contained">
-                    Send track buttons
+                    Send track poll
                 </LoadingButton>
             </Stack>
 
@@ -163,7 +164,7 @@ export const TrackManagementSection = ({ event }: { event: Event }) => {
 
             <Box mt={2}>
                 <Typography variant="subtitle2" gutterBottom>
-                    Webhook (required to receive button taps)
+                    Webhook (required to receive poll votes)
                 </Typography>
                 <Typography variant="body2" color="text.secondary" mb={1}>
                     Click to point your GreenAPI instance at this app automatically (sets the URL, the auth token and

--- a/src/events/page/whatsapp/TrackManagementSection.tsx
+++ b/src/events/page/whatsapp/TrackManagementSection.tsx
@@ -1,5 +1,5 @@
-import { useCallback, useEffect, useState } from 'react'
-import { Box, Card, Chip, Grid, Stack, TextField, Typography } from '@mui/material'
+import { useState } from 'react'
+import { Box, Card, Stack, TextField, Typography } from '@mui/material'
 import LoadingButton from '@mui/lab/LoadingButton'
 import { doc, updateDoc } from 'firebase/firestore'
 import { Event } from '../../../types'
@@ -8,13 +8,7 @@ import { useNotification } from '../../../hooks/notificationHook'
 import { TypographyCopyable } from '../../../components/TypographyCopyable'
 import { collections } from '../../../services/firebase'
 import { API_URL } from '../../../env'
-
-type TrackStatus = { id: string; name: string; ready: boolean }
-type SessionStatus = {
-    chatId: string | null
-    tracks: TrackStatus[]
-    goSent: boolean
-}
+import { TrackPollPanel } from './TrackPollPanel'
 
 // API_URL may or may not carry a trailing slash; normalise so the URL is always well-formed.
 const apiBase = String(API_URL ?? '').replace(/\/+$/, '')
@@ -25,9 +19,7 @@ export const TrackManagementSection = ({ event }: { event: Event }) => {
     const { createNotification } = useNotification()
     // Seed from the saved event setting so the operator doesn't retype it.
     const [chatId, setChatId] = useState(event.whatsappSharedChatId || '')
-    const [starting, setStarting] = useState(false)
     const [savingChat, setSavingChat] = useState(false)
-    const [status, setStatus] = useState<SessionStatus | null>(null)
 
     const saveSharedChat = async () => {
         setSavingChat(true)
@@ -42,29 +34,6 @@ export const TrackManagementSection = ({ event }: { event: Event }) => {
             setSavingChat(false)
         }
     }
-
-    const refresh = useCallback(async () => {
-        try {
-            const s = await fetchOpenPlannerApi<SessionStatus>(event, 'whatsapp/track-management/status', {
-                method: 'GET',
-            })
-            setStatus(s)
-            // Prefill the input from the last stored chat so the operator doesn't retype it (without
-            // clobbering anything they're currently typing).
-            if (s?.chatId) {
-                setChatId((prev) => prev || s.chatId || '')
-            }
-        } catch {
-            // status polling is best-effort
-        }
-    }, [event])
-
-    // Poll so button presses (handled via the GreenAPI webhook) show up without a manual reload.
-    useEffect(() => {
-        refresh()
-        const id = setInterval(refresh, 5000)
-        return () => clearInterval(id)
-    }, [refresh])
 
     const [configuring, setConfiguring] = useState(false)
     const configureWebhook = async () => {
@@ -87,30 +56,6 @@ export const TrackManagementSection = ({ event }: { event: Event }) => {
         }
     }
 
-    const start = async () => {
-        setStarting(true)
-        try {
-            await fetchOpenPlannerApi(event, 'whatsapp/track-management/start', {
-                method: 'POST',
-                body: { chatId },
-            })
-            // Remember the chat for next time.
-            await updateDoc(doc(collections.events, event.id), { whatsappSharedChatId: chatId.trim() || null })
-            createNotification('Track buttons sent', { type: 'success' })
-            await refresh()
-        } catch (error) {
-            createNotification('Failed to start: ' + (error instanceof Error ? error.message : 'Unknown error'), {
-                type: 'error',
-            })
-        } finally {
-            setStarting(false)
-        }
-    }
-
-    const trackList = status?.tracks ?? []
-    const readyCount = trackList.filter((t) => t.ready).length
-    const total = trackList.length
-
     return (
         <Card sx={{ paddingX: 2, mt: 4, mb: 2 }}>
             <Typography fontSize="large" sx={{ mt: 2, mb: 1 }}>
@@ -118,7 +63,9 @@ export const TrackManagementSection = ({ event }: { event: Event }) => {
             </Typography>
             <Typography variant="body2" color="text.secondary" mb={2}>
                 Send a WhatsApp poll listing the tracks (up to 12 options per poll). When a track manager taps their
-                track in the poll it is marked ready; once every track is ready, a GO message is sent to the same chat.
+                track in the poll it is marked ready; once every track is ready, you can send the GO message to the same
+                chat. Sending GO also auto-schedules the 15/10/5 min and end-of-session reminders on a 50min clock — use
+                the buttons below to send any of them manually if timing needs to change.
             </Typography>
 
             <TextField
@@ -134,33 +81,9 @@ export const TrackManagementSection = ({ event }: { event: Event }) => {
                 <LoadingButton onClick={saveSharedChat} disabled={savingChat} loading={savingChat} variant="outlined">
                     Save chat
                 </LoadingButton>
-                <LoadingButton
-                    onClick={start}
-                    disabled={starting || chatId.trim().length === 0}
-                    loading={starting}
-                    variant="contained">
-                    Send track poll
-                </LoadingButton>
             </Stack>
 
-            {total > 0 && (
-                <Box mb={2}>
-                    <Typography variant="subtitle2" gutterBottom>
-                        Readiness {readyCount}/{total}
-                        {status?.goSent ? ' — GO sent 🟢' : ''}
-                    </Typography>
-                    <Stack direction="row" spacing={1} flexWrap="wrap" useFlexGap>
-                        {trackList.map((t) => (
-                            <Chip
-                                key={t.id}
-                                label={t.name}
-                                color={t.ready ? 'success' : 'default'}
-                                variant={t.ready ? 'filled' : 'outlined'}
-                            />
-                        ))}
-                    </Stack>
-                </Box>
-            )}
+            <TrackPollPanel event={event} chatId={chatId} />
 
             <Box mt={2}>
                 <Typography variant="subtitle2" gutterBottom>

--- a/src/events/page/whatsapp/TrackManagementSection.tsx
+++ b/src/events/page/whatsapp/TrackManagementSection.tsx
@@ -29,6 +29,11 @@ export const TrackManagementSection = ({ event }: { event: Event }) => {
                 method: 'GET',
             })
             setStatus(s)
+            // Prefill the input from the last stored chat so the operator doesn't retype it (without
+            // clobbering anything they're currently typing).
+            if (s?.chatId) {
+                setChatId((prev) => prev || s.chatId || '')
+            }
         } catch {
             // status polling is best-effort
         }
@@ -118,6 +123,13 @@ export const TrackManagementSection = ({ event }: { event: Event }) => {
                     GreenAPI webhook URL (set it in your instance settings so button taps are received)
                 </Typography>
                 <TypographyCopyable singleLine={true}>{webhookUrl}</TypographyCopyable>
+
+                <Typography variant="body2" gutterBottom mt={2}>
+                    Webhook Authorization header (set the same value in GreenAPI so taps are trusted)
+                </Typography>
+                <TypographyCopyable singleLine={true}>
+                    {event.apiKey || '— generate an API key first'}
+                </TypographyCopyable>
             </Box>
         </Card>
     )

--- a/src/events/page/whatsapp/TrackManagementSection.tsx
+++ b/src/events/page/whatsapp/TrackManagementSection.tsx
@@ -46,6 +46,27 @@ export const TrackManagementSection = ({ event }: { event: Event }) => {
         return () => clearInterval(id)
     }, [refresh])
 
+    const [configuring, setConfiguring] = useState(false)
+    const configureWebhook = async () => {
+        setConfiguring(true)
+        try {
+            await fetchOpenPlannerApi(event, 'whatsapp/configure-webhook', {
+                method: 'POST',
+                body: { webhookUrl },
+            })
+            createNotification('GreenAPI webhook configured (the instance may reboot for a few minutes)', {
+                type: 'success',
+            })
+        } catch (error) {
+            createNotification(
+                'Failed to configure webhook: ' + (error instanceof Error ? error.message : 'Unknown error'),
+                { type: 'error' }
+            )
+        } finally {
+            setConfiguring(false)
+        }
+    }
+
     const start = async () => {
         setStarting(true)
         try {
@@ -119,13 +140,28 @@ export const TrackManagementSection = ({ event }: { event: Event }) => {
             )}
 
             <Box mt={2}>
+                <Typography variant="subtitle2" gutterBottom>
+                    Webhook (required to receive button taps)
+                </Typography>
+                <Typography variant="body2" color="text.secondary" mb={1}>
+                    Click to point your GreenAPI instance at this app automatically (sets the URL, the auth token and
+                    enables incoming notifications). The instance may reboot for a few minutes afterwards.
+                </Typography>
+                <LoadingButton
+                    onClick={configureWebhook}
+                    disabled={configuring || !event.apiKey}
+                    loading={configuring}
+                    variant="outlined"
+                    sx={{ mb: 2 }}>
+                    Configure GreenAPI webhook
+                </LoadingButton>
+
                 <Typography variant="body2" gutterBottom>
-                    GreenAPI webhook URL (set it in your instance settings so button taps are received)
+                    Or set these manually in GreenAPI — webhook URL:
                 </Typography>
                 <TypographyCopyable singleLine={true}>{webhookUrl}</TypographyCopyable>
-
                 <Typography variant="body2" gutterBottom mt={2}>
-                    Webhook Authorization header (set the same value in GreenAPI so taps are trusted)
+                    and Authorization token (webhookUrlToken):
                 </Typography>
                 <TypographyCopyable singleLine={true}>
                     {event.apiKey || '— generate an API key first'}

--- a/src/events/page/whatsapp/TrackManagementSection.tsx
+++ b/src/events/page/whatsapp/TrackManagementSection.tsx
@@ -1,63 +1,13 @@
-import { useState } from 'react'
-import { Box, Card, Stack, TextField, Typography } from '@mui/material'
-import LoadingButton from '@mui/lab/LoadingButton'
-import { doc, updateDoc } from 'firebase/firestore'
+import { Alert, Card, Typography } from '@mui/material'
 import { Event } from '../../../types'
-import { fetchOpenPlannerApi } from '../../../services/hooks/useOpenPlannerApi'
-import { useNotification } from '../../../hooks/notificationHook'
-import { TypographyCopyable } from '../../../components/TypographyCopyable'
-import { collections } from '../../../services/firebase'
-import { API_URL } from '../../../env'
 import { TrackPollPanel } from './TrackPollPanel'
 
-// API_URL may or may not carry a trailing slash; normalise so the URL is always well-formed.
-const apiBase = String(API_URL ?? '').replace(/\/+$/, '')
-
 export const TrackManagementSection = ({ event }: { event: Event }) => {
-    // Event-scoped webhook so GreenAPI posts straight to this event's endpoint.
-    const webhookUrl = `${apiBase}/v1/${event.id}/whatsapp/webhook`
-    const { createNotification } = useNotification()
-    // Seed from the saved event setting so the operator doesn't retype it.
-    const [chatId, setChatId] = useState(event.whatsappSharedChatId || '')
-    const [savingChat, setSavingChat] = useState(false)
-
-    const saveSharedChat = async () => {
-        setSavingChat(true)
-        try {
-            await updateDoc(doc(collections.events, event.id), { whatsappSharedChatId: chatId.trim() || null })
-            createNotification('Shared chat saved', { type: 'success' })
-        } catch (error) {
-            createNotification('Failed to save chat: ' + (error instanceof Error ? error.message : 'Unknown error'), {
-                type: 'error',
-            })
-        } finally {
-            setSavingChat(false)
-        }
-    }
-
-    const [configuring, setConfiguring] = useState(false)
-    const configureWebhook = async () => {
-        setConfiguring(true)
-        try {
-            await fetchOpenPlannerApi(event, 'whatsapp/configure-webhook', {
-                method: 'POST',
-                body: { webhookUrl },
-            })
-            createNotification('GreenAPI webhook configured (the instance may reboot for a few minutes)', {
-                type: 'success',
-            })
-        } catch (error) {
-            createNotification(
-                'Failed to configure webhook: ' + (error instanceof Error ? error.message : 'Unknown error'),
-                { type: 'error' }
-            )
-        } finally {
-            setConfiguring(false)
-        }
-    }
+    // The shared chat is set in the configuration modal; the poll is sent to it.
+    const chatId = event.whatsappSharedChatId || ''
 
     return (
-        <Card sx={{ paddingX: 2, mt: 4, mb: 2 }}>
+        <Card sx={{ paddingX: 2, mt: 2, mb: 2 }}>
             <Typography fontSize="large" sx={{ mt: 2, mb: 1 }}>
                 Track management
             </Typography>
@@ -68,51 +18,17 @@ export const TrackManagementSection = ({ event }: { event: Event }) => {
                 the buttons below to send any of them manually if timing needs to change.
             </Typography>
 
-            <TextField
-                margin="normal"
-                fullWidth
-                label="Shared chat (chatId ending with @c.us or @g.us)"
-                value={chatId}
-                onChange={(e) => setChatId(e.target.value)}
-                placeholder="120363xxxxxxxxxx@g.us"
-                helperText="A group chatId ends with @g.us, a single contact with @c.us. A raw phone number (international format) is sent to @c.us automatically."
-            />
-            <Stack direction="row" spacing={1} sx={{ mt: 1, mb: 2 }}>
-                <LoadingButton onClick={saveSharedChat} disabled={savingChat} loading={savingChat} variant="outlined">
-                    Save chat
-                </LoadingButton>
-            </Stack>
+            {chatId ? (
+                <Typography variant="body2" color="text.secondary" mb={2}>
+                    Shared chat: <code>{chatId}</code>
+                </Typography>
+            ) : (
+                <Alert severity="warning" sx={{ mb: 2 }}>
+                    No shared chat set — open the configuration to set the chatId before sending a poll.
+                </Alert>
+            )}
 
             <TrackPollPanel event={event} chatId={chatId} />
-
-            <Box mt={2}>
-                <Typography variant="subtitle2" gutterBottom>
-                    Webhook (required to receive poll votes)
-                </Typography>
-                <Typography variant="body2" color="text.secondary" mb={1}>
-                    Click to point your GreenAPI instance at this app automatically (sets the URL, the auth token and
-                    enables incoming notifications). The instance may reboot for a few minutes afterwards.
-                </Typography>
-                <LoadingButton
-                    onClick={configureWebhook}
-                    disabled={configuring || !event.apiKey}
-                    loading={configuring}
-                    variant="outlined"
-                    sx={{ mb: 2 }}>
-                    Configure GreenAPI webhook
-                </LoadingButton>
-
-                <Typography variant="body2" gutterBottom>
-                    Or set these manually in GreenAPI — webhook URL:
-                </Typography>
-                <TypographyCopyable singleLine={true}>{webhookUrl}</TypographyCopyable>
-                <Typography variant="body2" gutterBottom mt={2}>
-                    and Authorization token (webhookUrlToken):
-                </Typography>
-                <TypographyCopyable singleLine={true}>
-                    {event.apiKey || '— generate an API key first'}
-                </TypographyCopyable>
-            </Box>
         </Card>
     )
 }

--- a/src/events/page/whatsapp/TrackPollPanel.tsx
+++ b/src/events/page/whatsapp/TrackPollPanel.tsx
@@ -74,12 +74,66 @@ export const TrackPollPanel = ({ event, chatId }: TrackPollPanelProps) => {
         }
     }, [event])
 
-    // Poll so button presses (handled via the GreenAPI webhook) and scheduled reminders show up
-    // without a manual reload.
+    // Poll every 3s so poll votes (via the GreenAPI webhook) and scheduled reminders show up without a
+    // manual reload — but only while the window is focused. Polling pauses on blur/tab-hide and resumes
+    // (with an immediate refresh) on focus, and hard-stops after 2h with no focus activity so a
+    // forgotten tab doesn't poll forever.
     useEffect(() => {
-        refresh()
-        const id = setInterval(refresh, 5000)
-        return () => clearInterval(id)
+        const INACTIVITY_MS = 2 * 60 * 60 * 1000
+        let timer: ReturnType<typeof setInterval> | null = null
+        let deadline = Date.now() + INACTIVITY_MS
+        // Track focus via blur/focus events (document.hasFocus() is unreliable in embedded contexts);
+        // assume focused on mount.
+        let blurred = false
+
+        const stop = () => {
+            if (timer) {
+                clearInterval(timer)
+                timer = null
+            }
+        }
+        const startPolling = () => {
+            if (timer) return
+            refresh()
+            timer = setInterval(() => {
+                if (Date.now() > deadline) {
+                    stop()
+                    return
+                }
+                refresh()
+            }, 3000)
+        }
+
+        const sync = () => {
+            if (!document.hidden && !blurred) {
+                // Focus/visibility regained counts as activity: push the inactivity deadline back.
+                deadline = Date.now() + INACTIVITY_MS
+                startPolling()
+            } else {
+                stop()
+            }
+        }
+
+        const onFocus = () => {
+            blurred = false
+            sync()
+        }
+        const onBlur = () => {
+            blurred = true
+            sync()
+        }
+
+        window.addEventListener('focus', onFocus)
+        window.addEventListener('blur', onBlur)
+        document.addEventListener('visibilitychange', sync)
+        sync()
+
+        return () => {
+            window.removeEventListener('focus', onFocus)
+            window.removeEventListener('blur', onBlur)
+            document.removeEventListener('visibilitychange', sync)
+            stop()
+        }
     }, [refresh])
 
     const start = async () => {
@@ -120,6 +174,24 @@ export const TrackPollPanel = ({ event, chatId }: TrackPollPanelProps) => {
         }
     }
 
+    // The conference slot currently running: sessions whose window spans now; takes the latest such
+    // start (the slot in progress) and that slot's end.
+    const currentSlot = useMemo(() => {
+        const now = DateTime.now()
+        const running = (sessions ?? []).filter(
+            (s) => s.dates?.start && s.dates?.end && s.dates.start <= now && s.dates.end > now
+        )
+        if (running.length === 0) return null
+        const start = running.reduce(
+            (max, s) => (s.dates!.start! > max ? s.dates!.start! : max),
+            running[0].dates!.start!
+        )
+        const end = running
+            .filter((s) => +s.dates!.start! === +start)
+            .reduce((max, s) => (s.dates?.end && s.dates.end > max ? s.dates.end : max), start)
+        return { start, end }
+    }, [sessions])
+
     // The next upcoming conference slot: soonest session start in the future, with the slot's end.
     const nextSlot = useMemo(() => {
         const now = DateTime.now()
@@ -134,6 +206,11 @@ export const TrackPollPanel = ({ event, chatId }: TrackPollPanelProps) => {
             .reduce((max, s) => (s.dates?.end && s.dates.end > max ? s.dates.end : max), start)
         return { start, end }
     }, [sessions])
+
+    const formatSlot = (slot: { start: DateTime; end: DateTime }): string => {
+        const fmt = slot.start.hasSame(DateTime.now(), 'day') ? 'HH:mm' : 'ccc dd LLL HH:mm'
+        return `${slot.start.toFormat(fmt)} – ${slot.end.toFormat('HH:mm')}`
+    }
 
     const trackList = status?.tracks ?? []
     const readyCount = trackList.filter((t) => t.ready).length
@@ -153,14 +230,10 @@ export const TrackPollPanel = ({ event, chatId }: TrackPollPanelProps) => {
 
     return (
         <Box>
+            {currentSlot && <Typography variant="subtitle2">Current conference: {formatSlot(currentSlot)}</Typography>}
             {nextSlot && (
                 <Typography variant="subtitle2" gutterBottom>
-                    Next conference:{' '}
-                    {nextSlot.start.toFormat(
-                        nextSlot.start.hasSame(DateTime.now(), 'day') ? 'HH:mm' : 'ccc dd LLL HH:mm'
-                    )}
-                    {' – '}
-                    {nextSlot.end.toFormat('HH:mm')}
+                    Next conference: {formatSlot(nextSlot)}
                 </Typography>
             )}
             <FormControlLabel

--- a/src/events/page/whatsapp/TrackPollPanel.tsx
+++ b/src/events/page/whatsapp/TrackPollPanel.tsx
@@ -12,6 +12,7 @@ type SessionStatus = {
     chatId: string | null
     tracks: TrackStatus[]
     goSent: boolean
+    panelsSent: string[]
 }
 
 export type TrackPollPanelProps = {
@@ -19,7 +20,8 @@ export type TrackPollPanelProps = {
     chatId: string
 }
 
-// Preset timing announcements sent verbatim to the shared chat.
+// Timing reminders auto-scheduled by the backend when GO is sent — kept here only to render their
+// status (sent/pending), matched against SessionStatus.panelsSent.
 const PANEL_MESSAGES = ['Panneau 15 min', 'Panneau 10 min', 'Panneau 5 min', 'Fin de session']
 
 // Sends the track poll, polls for the resulting readiness, and lets the operator broadcast GO once
@@ -28,7 +30,6 @@ export const TrackPollPanel = ({ event, chatId }: TrackPollPanelProps) => {
     const { createNotification } = useNotification()
     const [starting, setStarting] = useState(false)
     const [sendingGo, setSendingGo] = useState(false)
-    const [sendingPanel, setSendingPanel] = useState<string | null>(null)
     const [status, setStatus] = useState<SessionStatus | null>(null)
 
     const refresh = useCallback(async () => {
@@ -42,7 +43,8 @@ export const TrackPollPanel = ({ event, chatId }: TrackPollPanelProps) => {
         }
     }, [event])
 
-    // Poll so button presses (handled via the GreenAPI webhook) show up without a manual reload.
+    // Poll so button presses (handled via the GreenAPI webhook) and scheduled reminders show up
+    // without a manual reload.
     useEffect(() => {
         refresh()
         const id = setInterval(refresh, 5000)
@@ -84,27 +86,11 @@ export const TrackPollPanel = ({ event, chatId }: TrackPollPanelProps) => {
         }
     }
 
-    const sendPanelMessage = async (message: string) => {
-        setSendingPanel(message)
-        try {
-            await fetchOpenPlannerApi(event, 'whatsapp/track-management/message', {
-                method: 'POST',
-                body: { message },
-            })
-            createNotification(`"${message}" sent`, { type: 'success' })
-        } catch (error) {
-            createNotification('Failed to send: ' + (error instanceof Error ? error.message : 'Unknown error'), {
-                type: 'error',
-            })
-        } finally {
-            setSendingPanel(null)
-        }
-    }
-
     const trackList = status?.tracks ?? []
     const readyCount = trackList.filter((t) => t.ready).length
     const total = trackList.length
     const allTracksReady = total > 0 && readyCount === total
+    const panelsSent = status?.panelsSent ?? []
 
     return (
         <Box>
@@ -133,27 +119,34 @@ export const TrackPollPanel = ({ event, chatId }: TrackPollPanelProps) => {
                             />
                         ))}
                     </Stack>
-                    <Stack direction="row" spacing={1} flexWrap="wrap" useFlexGap sx={{ mt: 2 }}>
-                        {allTracksReady && !status?.goSent && (
-                            <LoadingButton
-                                onClick={sendGo}
-                                disabled={sendingGo}
-                                loading={sendingGo}
-                                variant="contained"
-                                color="success">
-                                Send GO message
-                            </LoadingButton>
-                        )}
-                        {PANEL_MESSAGES.map((message) => (
-                            <LoadingButton
-                                key={message}
-                                onClick={() => sendPanelMessage(message)}
-                                disabled={sendingPanel !== null}
-                                loading={sendingPanel === message}
-                                variant="outlined">
-                                {message}
-                            </LoadingButton>
-                        ))}
+
+                    {allTracksReady && !status?.goSent && (
+                        <LoadingButton
+                            onClick={sendGo}
+                            disabled={sendingGo}
+                            loading={sendingGo}
+                            variant="contained"
+                            color="success"
+                            sx={{ mt: 2 }}>
+                            Send GO message
+                        </LoadingButton>
+                    )}
+
+                    <Typography variant="subtitle2" gutterBottom sx={{ mt: 2 }}>
+                        Reminders
+                    </Typography>
+                    <Stack direction="row" spacing={1} flexWrap="wrap" useFlexGap>
+                        {PANEL_MESSAGES.map((message) => {
+                            const sent = panelsSent.includes(message)
+                            return (
+                                <Chip
+                                    key={message}
+                                    label={message}
+                                    color={sent ? 'success' : 'default'}
+                                    variant={sent ? 'filled' : 'outlined'}
+                                />
+                            )
+                        })}
                     </Stack>
                 </Box>
             )}

--- a/src/events/page/whatsapp/TrackPollPanel.tsx
+++ b/src/events/page/whatsapp/TrackPollPanel.tsx
@@ -27,16 +27,16 @@ export type TrackPollPanelProps = {
 type PanelMessage = { message: string; delaySeconds: number }
 
 const TALK_PANEL_CONFIGURATION: PanelMessage[] = [
-    { message: 'Panneau 15 min', delaySeconds: 1 * 60 },
-    { message: 'Panneau 10 min', delaySeconds: 2 * 60 },
-    { message: 'Panneau 5 min', delaySeconds: 3 * 60 },
-    { message: 'Fin de session', delaySeconds: 4 * 60 },
+    { message: 'Panneau 15 min', delaySeconds: 35 * 60 },
+    { message: 'Panneau 10 min', delaySeconds: 40 * 60 },
+    { message: 'Panneau 5 min', delaySeconds: 45 * 60 },
+    { message: 'Fin de session', delaySeconds: 50 * 60 },
 ]
 
 const QUICKY_PANEL_CONFIGURATION: PanelMessage[] = [
-    { message: 'Panneau 10 min', delaySeconds: 1 * 60 },
-    { message: 'Panneau 5 min', delaySeconds: 2 * 60 },
-    { message: 'Fin de session', delaySeconds: 3 * 60 },
+    { message: 'Panneau 10 min', delaySeconds: 10 * 60 },
+    { message: 'Panneau 5 min', delaySeconds: 15 * 60 },
+    { message: 'Fin de session', delaySeconds: 20 * 60 },
 ]
 
 // Sends the track poll, polls for the resulting readiness, and lets the operator broadcast GO once

--- a/src/events/page/whatsapp/TrackPollPanel.tsx
+++ b/src/events/page/whatsapp/TrackPollPanel.tsx
@@ -1,11 +1,15 @@
-import { useCallback, useEffect, useState } from 'react'
-import { Box, Chip, Stack, Typography } from '@mui/material'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { Box, Checkbox, Chip, FormControlLabel, FormGroup, Stack, Typography } from '@mui/material'
 import LoadingButton from '@mui/lab/LoadingButton'
 import { doc, updateDoc } from 'firebase/firestore'
+import { useLocalStorage } from '@uidotdev/usehooks'
+import { DateTime } from 'luxon'
 import { Event } from '../../../types'
 import { fetchOpenPlannerApi } from '../../../services/hooks/useOpenPlannerApi'
 import { useNotification } from '../../../hooks/notificationHook'
+import { useSessions } from '../../../services/hooks/useSessions'
 import { collections } from '../../../services/firebase'
+import { ScheduledRemindersList } from './ScheduledRemindersList'
 
 type TrackStatus = { id: string; name: string; ready: boolean }
 type SessionStatus = {
@@ -28,9 +32,16 @@ const PANEL_MESSAGES = ['Panneau 15 min', 'Panneau 10 min', 'Panneau 5 min', 'Fi
 // every track has voted ready.
 export const TrackPollPanel = ({ event, chatId }: TrackPollPanelProps) => {
     const { createNotification } = useNotification()
+    const { data: sessions } = useSessions(event)
     const [starting, setStarting] = useState(false)
     const [sendingGo, setSendingGo] = useState(false)
     const [status, setStatus] = useState<SessionStatus | null>(null)
+    // Which reminders to auto-schedule when GO is sent. All by default, persisted per event.
+    const [autoPanels, setAutoPanels] = useLocalStorage<string[]>(`whatsapp-auto-panels-${event.id}`, PANEL_MESSAGES)
+
+    const togglePanel = (message: string) => {
+        setAutoPanels(autoPanels.includes(message) ? autoPanels.filter((m) => m !== message) : [...autoPanels, message])
+    }
 
     const refresh = useCallback(async () => {
         try {
@@ -71,10 +82,13 @@ export const TrackPollPanel = ({ event, chatId }: TrackPollPanelProps) => {
         }
     }
 
-    const sendGo = async () => {
+    const sendGo = async (force = false) => {
         setSendingGo(true)
         try {
-            await fetchOpenPlannerApi(event, 'whatsapp/track-management/go', { method: 'POST' })
+            await fetchOpenPlannerApi(event, 'whatsapp/track-management/go', {
+                method: 'POST',
+                body: { panels: autoPanels, force },
+            })
             createNotification('GO message sent', { type: 'success' })
             await refresh()
         } catch (error) {
@@ -86,14 +100,49 @@ export const TrackPollPanel = ({ event, chatId }: TrackPollPanelProps) => {
         }
     }
 
+    // The next upcoming conference slot: soonest session start in the future, with the slot's end.
+    const nextSlot = useMemo(() => {
+        const now = DateTime.now()
+        const upcoming = (sessions ?? []).filter((s) => s.dates?.start && s.dates.start > now)
+        if (upcoming.length === 0) return null
+        const start = upcoming.reduce(
+            (min, s) => (s.dates!.start! < min ? s.dates!.start! : min),
+            upcoming[0].dates!.start!
+        )
+        const end = upcoming
+            .filter((s) => +s.dates!.start! === +start)
+            .reduce((max, s) => (s.dates?.end && s.dates.end > max ? s.dates.end : max), start)
+        return { start, end }
+    }, [sessions])
+
     const trackList = status?.tracks ?? []
     const readyCount = trackList.filter((t) => t.ready).length
     const total = trackList.length
     const allTracksReady = total > 0 && readyCount === total
     const panelsSent = status?.panelsSent ?? []
 
+    // Buzz the device when the readiness count changes (a track manager just voted), so the operator
+    // notices without watching the screen. Skip the first render (ref starts null).
+    const prevReadyCount = useRef<number | null>(null)
+    useEffect(() => {
+        if (prevReadyCount.current !== null && readyCount !== prevReadyCount.current) {
+            navigator.vibrate?.(200)
+        }
+        prevReadyCount.current = readyCount
+    }, [readyCount])
+
     return (
         <Box>
+            {nextSlot && (
+                <Typography variant="subtitle2" gutterBottom>
+                    Next conference:{' '}
+                    {nextSlot.start.toFormat(
+                        nextSlot.start.hasSame(DateTime.now(), 'day') ? 'HH:mm' : 'ccc dd LLL HH:mm'
+                    )}
+                    {' – '}
+                    {nextSlot.end.toFormat('HH:mm')}
+                </Typography>
+            )}
             <LoadingButton
                 onClick={start}
                 disabled={starting || chatId.trim().length === 0}
@@ -122,7 +171,7 @@ export const TrackPollPanel = ({ event, chatId }: TrackPollPanelProps) => {
 
                     {allTracksReady && !status?.goSent && (
                         <LoadingButton
-                            onClick={sendGo}
+                            onClick={() => sendGo(false)}
                             disabled={sendingGo}
                             loading={sendingGo}
                             variant="contained"
@@ -132,22 +181,53 @@ export const TrackPollPanel = ({ event, chatId }: TrackPollPanelProps) => {
                         </LoadingButton>
                     )}
 
+                    {!allTracksReady && readyCount > 0 && !status?.goSent && (
+                        <LoadingButton
+                            onClick={() => sendGo(true)}
+                            disabled={sendingGo}
+                            loading={sendingGo}
+                            variant="outlined"
+                            color="warning"
+                            sx={{ mt: 2 }}>
+                            Force GO ({readyCount}/{total} ready)
+                        </LoadingButton>
+                    )}
+
                     <Typography variant="subtitle2" gutterBottom sx={{ mt: 2 }}>
-                        Reminders
+                        Auto reminders {status?.goSent ? '' : '(scheduled on GO)'}
                     </Typography>
-                    <Stack direction="row" spacing={1} flexWrap="wrap" useFlexGap>
-                        {PANEL_MESSAGES.map((message) => {
-                            const sent = panelsSent.includes(message)
-                            return (
-                                <Chip
+                    {status?.goSent ? (
+                        <Stack direction="row" spacing={1} flexWrap="wrap" useFlexGap>
+                            {PANEL_MESSAGES.map((message) => {
+                                const sent = panelsSent.includes(message)
+                                return (
+                                    <Chip
+                                        key={message}
+                                        label={message}
+                                        color={sent ? 'success' : 'default'}
+                                        variant={sent ? 'filled' : 'outlined'}
+                                    />
+                                )
+                            })}
+                        </Stack>
+                    ) : (
+                        <FormGroup row>
+                            {PANEL_MESSAGES.map((message) => (
+                                <FormControlLabel
                                     key={message}
+                                    control={
+                                        <Checkbox
+                                            checked={autoPanels.includes(message)}
+                                            onChange={() => togglePanel(message)}
+                                        />
+                                    }
                                     label={message}
-                                    color={sent ? 'success' : 'default'}
-                                    variant={sent ? 'filled' : 'outlined'}
                                 />
-                            )
-                        })}
-                    </Stack>
+                            ))}
+                        </FormGroup>
+                    )}
+
+                    {status?.goSent && <ScheduledRemindersList event={event} refreshSignal={panelsSent.length} />}
                 </Box>
             )}
         </Box>

--- a/src/events/page/whatsapp/TrackPollPanel.tsx
+++ b/src/events/page/whatsapp/TrackPollPanel.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import { Box, Checkbox, Chip, FormControlLabel, FormGroup, Stack, Typography } from '@mui/material'
+import { Box, Checkbox, Chip, FormControlLabel, FormGroup, Stack, Switch, Typography } from '@mui/material'
 import LoadingButton from '@mui/lab/LoadingButton'
 import { doc, updateDoc } from 'firebase/firestore'
 import { useLocalStorage } from '@uidotdev/usehooks'
@@ -24,9 +24,20 @@ export type TrackPollPanelProps = {
     chatId: string
 }
 
-// Timing reminders auto-scheduled by the backend when GO is sent — kept here only to render their
-// status (sent/pending), matched against SessionStatus.panelsSent.
-const PANEL_MESSAGES = ['Panneau 15 min', 'Panneau 10 min', 'Panneau 5 min', 'Fin de session']
+type PanelMessage = { message: string; delaySeconds: number }
+
+const TALK_PANEL_CONFIGURATION: PanelMessage[] = [
+    { message: 'Panneau 15 min', delaySeconds: 1 * 60 },
+    { message: 'Panneau 10 min', delaySeconds: 2 * 60 },
+    { message: 'Panneau 5 min', delaySeconds: 3 * 60 },
+    { message: 'Fin de session', delaySeconds: 4 * 60 },
+]
+
+const QUICKY_PANEL_CONFIGURATION: PanelMessage[] = [
+    { message: 'Panneau 10 min', delaySeconds: 1 * 60 },
+    { message: 'Panneau 5 min', delaySeconds: 2 * 60 },
+    { message: 'Fin de session', delaySeconds: 3 * 60 },
+]
 
 // Sends the track poll, polls for the resulting readiness, and lets the operator broadcast GO once
 // every track has voted ready.
@@ -36,11 +47,20 @@ export const TrackPollPanel = ({ event, chatId }: TrackPollPanelProps) => {
     const [starting, setStarting] = useState(false)
     const [sendingGo, setSendingGo] = useState(false)
     const [status, setStatus] = useState<SessionStatus | null>(null)
+    // false = Talk (default), true = Quicky. Persisted per event.
+    const [isQuicky, setIsQuicky] = useLocalStorage<boolean>(`whatsapp-quicky-mode-${event.id}`, false)
+    const panelConfig = isQuicky ? QUICKY_PANEL_CONFIGURATION : TALK_PANEL_CONFIGURATION
     // Which reminders to auto-schedule when GO is sent. All by default, persisted per event.
-    const [autoPanels, setAutoPanels] = useLocalStorage<string[]>(`whatsapp-auto-panels-${event.id}`, PANEL_MESSAGES)
+    const [autoPanels, setAutoPanels] = useLocalStorage<PanelMessage[]>(`whatsapp-auto-panels-${event.id}`, panelConfig)
 
-    const togglePanel = (message: string) => {
-        setAutoPanels(autoPanels.includes(message) ? autoPanels.filter((m) => m !== message) : [...autoPanels, message])
+    const switchConfig = (quicky: boolean) => {
+        setIsQuicky(quicky)
+        setAutoPanels(quicky ? QUICKY_PANEL_CONFIGURATION : TALK_PANEL_CONFIGURATION)
+    }
+
+    const togglePanel = (entry: PanelMessage) => {
+        const included = autoPanels.some((p) => p.message === entry.message)
+        setAutoPanels(included ? autoPanels.filter((p) => p.message !== entry.message) : [...autoPanels, entry])
     }
 
     const refresh = useCallback(async () => {
@@ -143,6 +163,12 @@ export const TrackPollPanel = ({ event, chatId }: TrackPollPanelProps) => {
                     {nextSlot.end.toFormat('HH:mm')}
                 </Typography>
             )}
+            <FormControlLabel
+                control={<Switch checked={!!isQuicky} onChange={(e) => switchConfig(e.target.checked)} />}
+                label={isQuicky ? 'Quicky' : 'Talk'}
+                sx={{ mb: 1 }}
+            />
+
             <LoadingButton
                 onClick={start}
                 disabled={starting || chatId.trim().length === 0}
@@ -198,12 +224,12 @@ export const TrackPollPanel = ({ event, chatId }: TrackPollPanelProps) => {
                     </Typography>
                     {status?.goSent ? (
                         <Stack direction="row" spacing={1} flexWrap="wrap" useFlexGap>
-                            {PANEL_MESSAGES.map((message) => {
-                                const sent = panelsSent.includes(message)
+                            {panelConfig.map((entry) => {
+                                const sent = panelsSent.includes(entry.message)
                                 return (
                                     <Chip
-                                        key={message}
-                                        label={message}
+                                        key={entry.message}
+                                        label={entry.message}
                                         color={sent ? 'success' : 'default'}
                                         variant={sent ? 'filled' : 'outlined'}
                                     />
@@ -212,16 +238,16 @@ export const TrackPollPanel = ({ event, chatId }: TrackPollPanelProps) => {
                         </Stack>
                     ) : (
                         <FormGroup row>
-                            {PANEL_MESSAGES.map((message) => (
+                            {panelConfig.map((entry) => (
                                 <FormControlLabel
-                                    key={message}
+                                    key={entry.message}
                                     control={
                                         <Checkbox
-                                            checked={autoPanels.includes(message)}
-                                            onChange={() => togglePanel(message)}
+                                            checked={autoPanels.some((p: PanelMessage) => p.message === entry.message)}
+                                            onChange={() => togglePanel(entry)}
                                         />
                                     }
-                                    label={message}
+                                    label={entry.message}
                                 />
                             ))}
                         </FormGroup>

--- a/src/events/page/whatsapp/TrackPollPanel.tsx
+++ b/src/events/page/whatsapp/TrackPollPanel.tsx
@@ -1,0 +1,162 @@
+import { useCallback, useEffect, useState } from 'react'
+import { Box, Chip, Stack, Typography } from '@mui/material'
+import LoadingButton from '@mui/lab/LoadingButton'
+import { doc, updateDoc } from 'firebase/firestore'
+import { Event } from '../../../types'
+import { fetchOpenPlannerApi } from '../../../services/hooks/useOpenPlannerApi'
+import { useNotification } from '../../../hooks/notificationHook'
+import { collections } from '../../../services/firebase'
+
+type TrackStatus = { id: string; name: string; ready: boolean }
+type SessionStatus = {
+    chatId: string | null
+    tracks: TrackStatus[]
+    goSent: boolean
+}
+
+export type TrackPollPanelProps = {
+    event: Event
+    chatId: string
+}
+
+// Preset timing announcements sent verbatim to the shared chat.
+const PANEL_MESSAGES = ['Panneau 15 min', 'Panneau 10 min', 'Panneau 5 min', 'Fin de session']
+
+// Sends the track poll, polls for the resulting readiness, and lets the operator broadcast GO once
+// every track has voted ready.
+export const TrackPollPanel = ({ event, chatId }: TrackPollPanelProps) => {
+    const { createNotification } = useNotification()
+    const [starting, setStarting] = useState(false)
+    const [sendingGo, setSendingGo] = useState(false)
+    const [sendingPanel, setSendingPanel] = useState<string | null>(null)
+    const [status, setStatus] = useState<SessionStatus | null>(null)
+
+    const refresh = useCallback(async () => {
+        try {
+            const s = await fetchOpenPlannerApi<SessionStatus>(event, 'whatsapp/track-management/status', {
+                method: 'GET',
+            })
+            setStatus(s)
+        } catch {
+            // status polling is best-effort
+        }
+    }, [event])
+
+    // Poll so button presses (handled via the GreenAPI webhook) show up without a manual reload.
+    useEffect(() => {
+        refresh()
+        const id = setInterval(refresh, 5000)
+        return () => clearInterval(id)
+    }, [refresh])
+
+    const start = async () => {
+        setStarting(true)
+        try {
+            await fetchOpenPlannerApi(event, 'whatsapp/track-management/start', {
+                method: 'POST',
+                body: { chatId },
+            })
+            // Remember the chat for next time.
+            await updateDoc(doc(collections.events, event.id), { whatsappSharedChatId: chatId.trim() || null })
+            createNotification('Track buttons sent', { type: 'success' })
+            await refresh()
+        } catch (error) {
+            createNotification('Failed to start: ' + (error instanceof Error ? error.message : 'Unknown error'), {
+                type: 'error',
+            })
+        } finally {
+            setStarting(false)
+        }
+    }
+
+    const sendGo = async () => {
+        setSendingGo(true)
+        try {
+            await fetchOpenPlannerApi(event, 'whatsapp/track-management/go', { method: 'POST' })
+            createNotification('GO message sent', { type: 'success' })
+            await refresh()
+        } catch (error) {
+            createNotification('Failed to send GO: ' + (error instanceof Error ? error.message : 'Unknown error'), {
+                type: 'error',
+            })
+        } finally {
+            setSendingGo(false)
+        }
+    }
+
+    const sendPanelMessage = async (message: string) => {
+        setSendingPanel(message)
+        try {
+            await fetchOpenPlannerApi(event, 'whatsapp/track-management/message', {
+                method: 'POST',
+                body: { message },
+            })
+            createNotification(`"${message}" sent`, { type: 'success' })
+        } catch (error) {
+            createNotification('Failed to send: ' + (error instanceof Error ? error.message : 'Unknown error'), {
+                type: 'error',
+            })
+        } finally {
+            setSendingPanel(null)
+        }
+    }
+
+    const trackList = status?.tracks ?? []
+    const readyCount = trackList.filter((t) => t.ready).length
+    const total = trackList.length
+    const allTracksReady = total > 0 && readyCount === total
+
+    return (
+        <Box>
+            <LoadingButton
+                onClick={start}
+                disabled={starting || chatId.trim().length === 0}
+                loading={starting}
+                variant="contained"
+                sx={{ mb: 2 }}>
+                Send track poll
+            </LoadingButton>
+
+            {total > 0 && (
+                <Box mb={2}>
+                    <Typography variant="subtitle2" gutterBottom>
+                        Readiness {readyCount}/{total}
+                        {status?.goSent ? ' — GO sent 🟢' : ''}
+                    </Typography>
+                    <Stack direction="row" spacing={1} flexWrap="wrap" useFlexGap>
+                        {trackList.map((t) => (
+                            <Chip
+                                key={t.id}
+                                label={t.name}
+                                color={t.ready ? 'success' : 'default'}
+                                variant={t.ready ? 'filled' : 'outlined'}
+                            />
+                        ))}
+                    </Stack>
+                    <Stack direction="row" spacing={1} flexWrap="wrap" useFlexGap sx={{ mt: 2 }}>
+                        {allTracksReady && !status?.goSent && (
+                            <LoadingButton
+                                onClick={sendGo}
+                                disabled={sendingGo}
+                                loading={sendingGo}
+                                variant="contained"
+                                color="success">
+                                Send GO message
+                            </LoadingButton>
+                        )}
+                        {PANEL_MESSAGES.map((message) => (
+                            <LoadingButton
+                                key={message}
+                                onClick={() => sendPanelMessage(message)}
+                                disabled={sendingPanel !== null}
+                                loading={sendingPanel === message}
+                                variant="outlined">
+                                {message}
+                            </LoadingButton>
+                        ))}
+                    </Stack>
+                </Box>
+            )}
+        </Box>
+    )
+}

--- a/src/events/page/whatsapp/WhatsAppChatPicker.tsx
+++ b/src/events/page/whatsapp/WhatsAppChatPicker.tsx
@@ -1,0 +1,105 @@
+import { useEffect, useMemo, useState } from 'react'
+import { Autocomplete, Chip, CircularProgress, TextField } from '@mui/material'
+import { Event } from '../../../types'
+import { fetchOpenPlannerApi } from '../../../services/hooks/useOpenPlannerApi'
+
+export type WhatsAppContact = { id: string; name: string; type: 'group' | 'user' }
+
+export type WhatsAppChatPickerProps = {
+    event: Event
+    value: string
+    onChange: (value: string) => void
+    // Which contacts to offer; 'all' keeps both groups and single contacts.
+    filterType?: 'group' | 'user' | 'all'
+    label: string
+    helperText?: string
+    disabled?: boolean
+}
+
+// Fetches the GreenAPI contacts (server-side, token never exposed) and lets the operator pick a chat.
+// freeSolo so a raw chatId or phone number can still be typed if it isn't in the list.
+export const WhatsAppChatPicker = ({
+    event,
+    value,
+    onChange,
+    filterType = 'all',
+    label,
+    helperText,
+    disabled,
+}: WhatsAppChatPickerProps) => {
+    const [contacts, setContacts] = useState<WhatsAppContact[]>([])
+    const [loading, setLoading] = useState(false)
+    const [error, setError] = useState<string | null>(null)
+
+    useEffect(() => {
+        let cancelled = false
+        setLoading(true)
+        setError(null)
+        fetchOpenPlannerApi<{ contacts: WhatsAppContact[] }>(event, 'whatsapp/contacts', { method: 'GET' })
+            .then((res) => {
+                if (!cancelled) setContacts(res.contacts || [])
+            })
+            .catch((err) => {
+                if (!cancelled) setError(err instanceof Error ? err.message : 'Failed to load contacts')
+            })
+            .finally(() => {
+                if (!cancelled) setLoading(false)
+            })
+        return () => {
+            cancelled = true
+        }
+    }, [event.id])
+
+    const options = useMemo(
+        () => (filterType === 'all' ? contacts : contacts.filter((c) => c.type === filterType)),
+        [contacts, filterType]
+    )
+
+    // Resolve the stored string id to its contact object so the input shows the friendly name.
+    const selected = options.find((c) => c.id === value) ?? (value ? value : null)
+
+    return (
+        <Autocomplete
+            freeSolo
+            disabled={disabled}
+            options={options}
+            value={selected}
+            loading={loading}
+            getOptionLabel={(option) => (typeof option === 'string' ? option : option.name || option.id)}
+            isOptionEqualToValue={(option, val) => option.id === (typeof val === 'string' ? val : val.id)}
+            onChange={(_, newValue) => {
+                if (newValue == null) onChange('')
+                else if (typeof newValue === 'string') onChange(newValue)
+                else onChange(newValue.id)
+            }}
+            // Capture a typed value (raw phone / chatId) that isn't selected from the list.
+            onInputChange={(_, newInput, reason) => {
+                if (reason === 'input') onChange(newInput)
+            }}
+            renderOption={(props, option) => (
+                <li {...props} key={option.id}>
+                    {option.name || option.id}
+                    {option.type === 'group' && <Chip label="group" size="small" sx={{ ml: 1 }} />}
+                </li>
+            )}
+            renderInput={(params) => (
+                <TextField
+                    {...params}
+                    margin="normal"
+                    label={label}
+                    helperText={error ? `Couldn't load contacts: ${error} — type a chatId manually.` : helperText}
+                    error={Boolean(error)}
+                    InputProps={{
+                        ...params.InputProps,
+                        endAdornment: (
+                            <>
+                                {loading ? <CircularProgress color="inherit" size={18} /> : null}
+                                {params.InputProps.endAdornment}
+                            </>
+                        ),
+                    }}
+                />
+            )}
+        />
+    )
+}

--- a/src/events/page/whatsapp/WhatsAppConfigModal.tsx
+++ b/src/events/page/whatsapp/WhatsAppConfigModal.tsx
@@ -1,0 +1,184 @@
+import { useEffect } from 'react'
+import * as yup from 'yup'
+import { doc } from 'firebase/firestore'
+import { FormContainer, TextFieldElement, useForm } from 'react-hook-form-mui'
+import { Controller } from 'react-hook-form'
+import { yupResolver } from '@hookform/resolvers/yup'
+import {
+    Alert,
+    Button,
+    Dialog,
+    DialogActions,
+    DialogContent,
+    DialogTitle,
+    Divider,
+    TextField,
+    Typography,
+} from '@mui/material'
+import LoadingButton from '@mui/lab/LoadingButton'
+import { Event, EventSettingForForm } from '../../../types'
+import { collections } from '../../../services/firebase'
+import { useFirestoreDocumentMutation } from '../../../services/hooks/firestoreMutationHooks'
+import { mapEventDevSettingsFormToMutateObject } from '../settings/mapEventSettingsFormToMutateObject'
+import { TextFieldElementPrivate } from '../../../components/form/TextFieldElementPrivate'
+import { SaveShortcut } from '../../../components/form/SaveShortcut'
+import { useNotification } from '../../../hooks/notificationHook'
+import { WhatsAppWebhookSetup } from './WhatsAppWebhookSetup'
+import { WhatsAppTestMessage } from './WhatsAppTestMessage'
+import { WhatsAppChatPicker } from './WhatsAppChatPicker'
+
+const schema = yup
+    .object({
+        greenApiInstanceId: yup.string().nullable(),
+        greenApiToken: yup.string().nullable(),
+        whatsappSharedChatId: yup.string().nullable(),
+    })
+    .required()
+
+// Carry the full settings shape (not just the GreenAPI fields): mapEventDevSettingsFormToMutateObject
+// reads webhooks/apiKey/publicEnabled/repoUrl from the submitted data, so omitting them would wipe them.
+const convertInputEvent = (event: Event): EventSettingForForm => ({
+    ...event,
+    webhooks: event.webhooks || [],
+    apiKey: event.apiKey,
+    publicEnabled: event.publicEnabled || false,
+    repoUrl: event.repoUrl || null,
+    repoToken: event.repoToken || null,
+    greenApiInstanceId: event.greenApiInstanceId || '',
+    greenApiToken: event.greenApiToken || '',
+    whatsappSharedChatId: event.whatsappSharedChatId || '',
+})
+
+export type WhatsAppConfigModalProps = {
+    open: boolean
+    onClose: () => void
+    event: Event
+}
+
+// Single place to set up everything WhatsApp needs: GreenAPI credentials, the shared chat, the webhook
+// and a test message. Auto-opened on first setup from the WhatsApp page.
+export const WhatsAppConfigModal = ({ open, onClose, event }: WhatsAppConfigModalProps) => {
+    const mutation = useFirestoreDocumentMutation(doc(collections.events, event.id))
+    const { createNotification } = useNotification()
+
+    const formContext = useForm({ defaultValues: convertInputEvent(event) })
+    const { formState, reset } = formContext
+
+    useEffect(() => {
+        reset(convertInputEvent(event))
+    }, [event])
+
+    const isConfigured = Boolean(event.greenApiInstanceId && event.greenApiToken)
+
+    return (
+        <Dialog open={open} onClose={onClose} maxWidth="md" fullWidth scroll="body">
+            <DialogTitle>WhatsApp configuration</DialogTitle>
+            <DialogContent>
+                <Alert severity="info" sx={{ mb: 2 }}>
+                    Messages are sent through{' '}
+                    <a href="https://green-api.com" target="_blank" rel="noreferrer">
+                        GreenAPI
+                    </a>
+                    . The free <strong>Developer</strong> plan is enough for track management. Create an instance, then
+                    paste its credentials below.
+                </Alert>
+
+                <FormContainer
+                    formContext={formContext}
+                    // @ts-ignore
+                    resolver={yupResolver(schema)}
+                    onSuccess={async (data) => {
+                        await mutation.mutate(mapEventDevSettingsFormToMutateObject(event, data))
+                        createNotification('WhatsApp configuration saved', { type: 'success' })
+                    }}>
+                    <Typography fontSize="large" sx={{ mb: 1 }}>
+                        1. GreenAPI credentials
+                    </Typography>
+                    <Typography variant="body2" color="text.secondary" mb={1}>
+                        The token never leaves the backend — messages are sent server-side.
+                    </Typography>
+                    <TextFieldElement
+                        margin="normal"
+                        fullWidth
+                        id="greenApiInstanceId"
+                        label="GreenAPI instance id"
+                        name="greenApiInstanceId"
+                        helperText="e.g. 7105xxxxxx"
+                    />
+                    <TextFieldElementPrivate
+                        margin="normal"
+                        fullWidth
+                        id="greenApiToken"
+                        label="GreenAPI API token"
+                        name="greenApiToken"
+                        variant="filled"
+                    />
+
+                    <Typography fontSize="large" sx={{ mt: 3, mb: 1 }}>
+                        2. Shared chat
+                    </Typography>
+                    <Controller
+                        name="whatsappSharedChatId"
+                        control={formContext.control}
+                        render={({ field }) =>
+                            isConfigured ? (
+                                <WhatsAppChatPicker
+                                    event={event}
+                                    value={field.value || ''}
+                                    onChange={field.onChange}
+                                    filterType="group"
+                                    label="Shared chat group"
+                                    helperText="Pick the WhatsApp group that receives the track poll. You can also type a chatId / phone manually."
+                                />
+                            ) : (
+                                <TextField
+                                    margin="normal"
+                                    fullWidth
+                                    label="Shared chat (chatId ending with @c.us or @g.us)"
+                                    value={field.value || ''}
+                                    onChange={(e) => field.onChange(e.target.value)}
+                                    placeholder="120363xxxxxxxxxx@g.us"
+                                    helperText="Save your GreenAPI credentials first to pick from your groups."
+                                />
+                            )
+                        }
+                    />
+
+                    <LoadingButton
+                        type="submit"
+                        disabled={formState.isSubmitting}
+                        loading={formState.isSubmitting}
+                        fullWidth
+                        variant="contained"
+                        sx={{ mt: 2 }}>
+                        Save configuration
+                    </LoadingButton>
+                    <SaveShortcut />
+                </FormContainer>
+
+                <Divider sx={{ my: 3 }} />
+
+                <Typography fontSize="large" sx={{ mb: 1 }}>
+                    3. Webhook (required to receive poll votes)
+                </Typography>
+                <WhatsAppWebhookSetup event={event} />
+
+                <Divider sx={{ my: 3 }} />
+
+                <Typography fontSize="large" sx={{ mb: 1 }}>
+                    4. Send a test message
+                </Typography>
+                {isConfigured ? (
+                    <WhatsAppTestMessage event={event} />
+                ) : (
+                    <Typography variant="body2" color="text.secondary" sx={{ pb: 2 }}>
+                        Save your GreenAPI instance id and token above to unlock sending.
+                    </Typography>
+                )}
+            </DialogContent>
+            <DialogActions>
+                <Button onClick={onClose}>Close</Button>
+            </DialogActions>
+        </Dialog>
+    )
+}

--- a/src/events/page/whatsapp/WhatsAppTestMessage.tsx
+++ b/src/events/page/whatsapp/WhatsAppTestMessage.tsx
@@ -1,0 +1,71 @@
+import { useState } from 'react'
+import { Box, Grid, TextField, Typography } from '@mui/material'
+import LoadingButton from '@mui/lab/LoadingButton'
+import { Event } from '../../../types'
+import { fetchOpenPlannerApi } from '../../../services/hooks/useOpenPlannerApi'
+import { useNotification } from '../../../hooks/notificationHook'
+import { WhatsAppChatPicker } from './WhatsAppChatPicker'
+
+export type WhatsAppTestMessageProps = {
+    event: Event
+}
+
+// One-off WhatsApp message to confirm the GreenAPI credentials actually work.
+export const WhatsAppTestMessage = ({ event }: WhatsAppTestMessageProps) => {
+    const { createNotification } = useNotification()
+    const [to, setTo] = useState('')
+    const [message, setMessage] = useState('Test message from OpenPlanner ✅')
+    const [sending, setSending] = useState(false)
+
+    const sendTest = async () => {
+        setSending(true)
+        try {
+            await fetchOpenPlannerApi(event, 'whatsapp/send-test', {
+                method: 'POST',
+                body: { to, message },
+            })
+            createNotification('WhatsApp message sent', { type: 'success' })
+        } catch (error) {
+            createNotification('Failed to send: ' + (error instanceof Error ? error.message : 'Unknown error'), {
+                type: 'error',
+            })
+        } finally {
+            setSending(false)
+        }
+    }
+
+    return (
+        <Box>
+            <Typography variant="body2" color="text.secondary" mb={2}>
+                Send one WhatsApp message to check the setup. Pick a contact below, or type a number in international
+                format (country code included), e.g. <code>+33612345678</code>.
+            </Typography>
+            <WhatsAppChatPicker
+                event={event}
+                value={to}
+                onChange={setTo}
+                filterType="all"
+                label="Recipient (contact, group or phone number)"
+            />
+            <TextField
+                margin="normal"
+                fullWidth
+                multiline
+                minRows={2}
+                label="Message"
+                value={message}
+                onChange={(e) => setMessage(e.target.value)}
+            />
+            <Grid item xs={12}>
+                <LoadingButton
+                    onClick={sendTest}
+                    disabled={sending || to.trim().length === 0 || message.trim().length === 0}
+                    loading={sending}
+                    variant="contained"
+                    sx={{ mt: 2, mb: 2 }}>
+                    Send test message
+                </LoadingButton>
+            </Grid>
+        </Box>
+    )
+}

--- a/src/events/page/whatsapp/WhatsAppWebhookSetup.tsx
+++ b/src/events/page/whatsapp/WhatsAppWebhookSetup.tsx
@@ -1,0 +1,69 @@
+import { useState } from 'react'
+import { Box, Typography } from '@mui/material'
+import LoadingButton from '@mui/lab/LoadingButton'
+import { Event } from '../../../types'
+import { fetchOpenPlannerApi } from '../../../services/hooks/useOpenPlannerApi'
+import { useNotification } from '../../../hooks/notificationHook'
+import { TypographyCopyable } from '../../../components/TypographyCopyable'
+import { API_URL } from '../../../env'
+
+// API_URL may or may not carry a trailing slash; normalise so the URL is always well-formed.
+const apiBase = String(API_URL ?? '').replace(/\/+$/, '')
+
+export type WhatsAppWebhookSetupProps = {
+    event: Event
+}
+
+// GreenAPI webhook wiring (required so poll votes reach this app). Auto-config button + manual fallback.
+export const WhatsAppWebhookSetup = ({ event }: WhatsAppWebhookSetupProps) => {
+    const { createNotification } = useNotification()
+    // Event-scoped webhook so GreenAPI posts straight to this event's endpoint.
+    const webhookUrl = `${apiBase}/v1/${event.id}/whatsapp/webhook`
+    const [configuring, setConfiguring] = useState(false)
+
+    const configureWebhook = async () => {
+        setConfiguring(true)
+        try {
+            await fetchOpenPlannerApi(event, 'whatsapp/configure-webhook', {
+                method: 'POST',
+                body: { webhookUrl },
+            })
+            createNotification('GreenAPI webhook configured (the instance may reboot for a few minutes)', {
+                type: 'success',
+            })
+        } catch (error) {
+            createNotification(
+                'Failed to configure webhook: ' + (error instanceof Error ? error.message : 'Unknown error'),
+                { type: 'error' }
+            )
+        } finally {
+            setConfiguring(false)
+        }
+    }
+
+    return (
+        <Box>
+            <Typography variant="body2" color="text.secondary" mb={1}>
+                Click to point your GreenAPI instance at this app automatically (sets the URL, the auth token and
+                enables incoming notifications). The instance may reboot for a few minutes afterwards.
+            </Typography>
+            <LoadingButton
+                onClick={configureWebhook}
+                disabled={configuring || !event.apiKey}
+                loading={configuring}
+                variant="outlined"
+                sx={{ mb: 2 }}>
+                Configure GreenAPI webhook
+            </LoadingButton>
+
+            <Typography variant="body2" gutterBottom>
+                Or set these manually in GreenAPI — webhook URL:
+            </Typography>
+            <TypographyCopyable singleLine={true}>{webhookUrl}</TypographyCopyable>
+            <Typography variant="body2" gutterBottom mt={2}>
+                and Authorization token (webhookUrlToken):
+            </Typography>
+            <TypographyCopyable singleLine={true}>{event.apiKey || '— generate an API key first'}</TypographyCopyable>
+        </Box>
+    )
+}

--- a/src/services/hooks/useOpenPlannerApi.ts
+++ b/src/services/hooks/useOpenPlannerApi.ts
@@ -10,7 +10,7 @@ type ApiResponse<T> = {
 }
 
 type RequestOptions = {
-    method?: 'GET' | 'POST'
+    method?: 'GET' | 'POST' | 'DELETE'
     body?: any
     query?: Record<string, string | number | boolean | undefined | null>
 }
@@ -41,7 +41,7 @@ export async function fetchOpenPlannerApi<T>(
         },
     }
 
-    if (options.body && options.method === 'POST') {
+    if (options.body && options.method !== 'GET') {
         fetchOptions.body = JSON.stringify(options.body)
     }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -261,6 +261,9 @@ export interface Event {
     repoToken?: string | null
     intermissionMediaUrl?: string | null
     intermissionPassword?: string | null
+    // GreenAPI (WhatsApp) credentials, used for track-management messaging
+    greenApiInstanceId?: string | null
+    greenApiToken?: string | null
 }
 
 export type EventForForm = Omit<Event, 'dates'> & {
@@ -280,6 +283,8 @@ export type EventSettingForForm = {
     intermissionPassword?: string | null
     gladiaAPIKey?: string | null
     transcriptionPassword?: string | null
+    greenApiInstanceId?: string | null
+    greenApiToken?: string | null
 }
 
 export type NewEvent = Omit<Omit<Omit<Event, 'id'>, 'createdAt'>, 'updatedAt'> & {

--- a/src/types.ts
+++ b/src/types.ts
@@ -264,6 +264,8 @@ export interface Event {
     // GreenAPI (WhatsApp) credentials, used for track-management messaging
     greenApiInstanceId?: string | null
     greenApiToken?: string | null
+    // Shared chat (phone or @g.us group) that receives the track-management buttons
+    whatsappSharedChatId?: string | null
 }
 
 export type EventForForm = Omit<Event, 'dates'> & {
@@ -285,6 +287,7 @@ export type EventSettingForForm = {
     transcriptionPassword?: string | null
     greenApiInstanceId?: string | null
     greenApiToken?: string | null
+    whatsappSharedChatId?: string | null
 }
 
 export type NewEvent = Omit<Omit<Omit<Event, 'id'>, 'createdAt'>, 'updatedAt'> & {


### PR DESCRIPTION
## Context

Automate track management over WhatsApp (chosen for robustness): each track confirms **ready** via a button tap, and once all tracks are ready an overall **GO** is sent to the shared chat. Uses [GreenAPI](https://green-api.com).

## Part 1 — setup
- `Event` gains `greenApiInstanceId` + `greenApiToken`, persisted via `mapEventDevSettingsFormToMutateObject` (guarded so other forms don't wipe them; the WhatsApp form carries the full settings shape).
- New admin page `/whatsapp` (`EventWhatsApp`), reachable from **Integration & API** via an "Open" card.
- Save GreenAPI creds; once set, a **test send** validates the setup.
- Backend `POST /v1/:eventId/whatsapp/send-test` (apiKey-protected) calls GreenAPI **server-side** — token never reaches the browser.

## Part 2 — interactive ready → GO flow
- **Send** [`SendInteractiveButtonsReply`](https://green-api.com/en/docs/api/sending/SendInteractiveButtonsReply/): one button per track, **max 3 per message**, tracks split across as many messages as needed (`POST /v1/:eventId/whatsapp/track-management/start`, body `{ chatId }`).
- **Receive** a global GreenAPI webhook `POST /v1/whatsapp/webhook` (no eventId — mapped back to the event by instance id). On a button tap it:
    - marks that track ready,
    - **edits** the (now button-less) message to a status recap,
    - **re-offers** buttons for the tracks still pending in that group (so grouped tracks stay tappable),
    - sends the **GO** message to the same chat once every track is ready (exactly once).
- **State** persisted per event at `events/{id}/whatsapp/current`; the admin page polls `GET /v1/:eventId/whatsapp/track-management/status` and shows readiness chips + GO status, and displays the webhook URL to paste into the GreenAPI instance settings.

### Structure
- `greenApi.ts` — thin GreenAPI client (send / interactive buttons / edit).
- `trackSession.ts` — session types + pure helpers (chunking, body/recap text, all-ready, GO).
- `trackFlow.ts` — start + press-handling orchestration with **injected senders** (network-free, unit-tested).
- `whatsappSessionDao.ts` — Firestore session + instance→event lookup.
- `whatsapp.ts` — routes. Frontend: `EventWhatsApp.tsx` + `TrackManagementSection.tsx`.

## Tests
- `functions/` suite: **237 passed** (incl. new `trackFlow.test.ts`: chunking, ready/edit/re-offer, single GO, idempotent press). Frontend `tsc` + functions build clean.

## Known limitations / follow-ups
- Webhook is unauthenticated (GreenAPI has no per-call secret by default); it only acts when the instance id maps to an event and a session exists. Could add a shared-secret header later.
- `editMessage` drops buttons (GreenAPI text-only), hence the re-offer of remaining buttons — expect one recap edit + one fresh message per tapped group.
- Webhook URL must be set in the GreenAPI instance settings (shown on the page); not auto-configured to avoid overwriting other settings.
- The exact incoming button-reply payload shape is parsed defensively across known GreenAPI fields; verify against a live instance.

## Manual test
Open event → Integration & API → WhatsApp → save GreenAPI instance/token → set the webhook URL in GreenAPI → "Send track buttons" to a chat → tap buttons → watch readiness + GO.