### PR TITLE
feat(intermission): persist screen options in the URL

### DIFF
--- a/src/public/intermission/IntermissionApp.tsx
+++ b/src/public/intermission/IntermissionApp.tsx
@@ -6,6 +6,7 @@ import { useIntermissionEvent } from '../hooks/useIntermissionEvent'
 import { useTalkSelection } from '../transcription/useTalkSelection'
 import { PublicJSON } from '../publicTypes'
 import { IntermissionScreen } from './IntermissionScreen'
+import { useQueryParam } from './useQueryParam'
 
 export type IntermissionAppProps = {
     eventId: string
@@ -13,8 +14,10 @@ export type IntermissionAppProps = {
 
 export const IntermissionApp = ({ eventId }: IntermissionAppProps) => {
     // Dedicated password, separate from the transcription page. Optional: only used when the event sets one.
+    // Kept in localStorage (never put a password in the URL).
     const [intermissionPassword, savePassword] = useLocalStorage<string>('intermissionPassword', '')
-    const [selectedTrack, setSelectedTrack] = useLocalStorage<string>('intermissionTrack', '')
+    // Picked track persists in the URL so a room screen's config is shareable/bookmarkable.
+    const [selectedTrack, setSelectedTrack] = useQueryParam('track', '')
     const [tempPassword, setTempPassword] = useState<string>('')
 
     const { eventData, isLoading, error, unauthorized } = useIntermissionEvent(eventId, intermissionPassword)

--- a/src/public/intermission/IntermissionScreen.tsx
+++ b/src/public/intermission/IntermissionScreen.tsx
@@ -1,8 +1,8 @@
 import { DateTime } from 'luxon'
 import { useEffect, useRef, useState } from 'react'
-import { useLocalStorage } from '@uidotdev/usehooks'
 import { PublicJSON } from '../publicTypes'
 import { formatRelativeStart, intermissionStrings } from './intermissionI18n'
+import { useQueryParam } from './useQueryParam'
 
 const IDLE_MS = 5000
 
@@ -93,11 +93,18 @@ export const IntermissionScreen = ({
     const startTime = nextTalk ? DateTime.fromISO(nextTalk.dateStart).toFormat('HH:mm') : ''
     const accent = categoryColor || DEFAULT_ACCENT
 
-    // Persisted display options (cog menu, top-right)
+    // Display options persisted in the URL (cog menu, top-right) so a screen's config is shareable
     const [settingsOpen, setSettingsOpen] = useState(false)
-    const [layoutScale, setLayoutScale] = useLocalStorage<number>('intermissionLayoutScale', 100)
-    const [intermittent, setIntermittent] = useLocalStorage<boolean>('intermissionIntermittent', false)
-    const [intervalSec, setIntervalSec] = useLocalStorage<number>('intermissionIntervalSec', 5)
+    const [sizeParam, setSizeParam] = useQueryParam('size', '100')
+    const [blinkParam, setBlinkParam] = useQueryParam('blink', '0')
+    const [intervalParam, setIntervalParam] = useQueryParam('interval', '5')
+
+    const layoutScale = Number(sizeParam) || 100
+    const intermittent = blinkParam === '1'
+    const intervalSec = Number(intervalParam) || 5
+    const setLayoutScale = (v: number) => setSizeParam(String(v))
+    const setIntermittent = (v: boolean) => setBlinkParam(v ? '1' : '0')
+    const setIntervalSec = (v: number) => setIntervalParam(String(v))
 
     // Intermittent display: cycle the card on for `intervalSec`, then off for the same duration
     const [cardShown, setCardShown] = useState(true)

--- a/src/public/intermission/useQueryParam.ts
+++ b/src/public/intermission/useQueryParam.ts
@@ -1,0 +1,29 @@
+import { useState } from 'react'
+
+/**
+ * Small string-valued query-param state. Reads the initial value from the URL and writes changes
+ * back via history.replaceState (no navigation), so the picked options are shareable/bookmarkable.
+ * Each setter reads the current search fresh, so independent params don't clobber each other.
+ */
+export const useQueryParam = (key: string, defaultValue: string): [string, (value: string) => void] => {
+    const [value, setValue] = useState<string>(() => {
+        if (typeof window === 'undefined') return defaultValue
+        const params = new URLSearchParams(window.location.search)
+        return params.has(key) ? (params.get(key) as string) : defaultValue
+    })
+
+    const set = (next: string) => {
+        setValue(next)
+        if (typeof window === 'undefined') return
+        const params = new URLSearchParams(window.location.search)
+        if (next === '' || next === null || next === undefined) {
+            params.delete(key)
+        } else {
+            params.set(key, next)
+        }
+        const qs = params.toString()
+        window.history.replaceState(null, '', `${window.location.pathname}${qs ? `?${qs}` : ''}${window.location.hash}`)
+    }
+
+    return [value, set]
+}


### PR DESCRIPTION
## What

The intermission screen's picked options now persist in the URL query string, so a configured room display is **shareable and bookmarkable** and survives reloads:

| Option | Query param |
|---|---|
| Track | `?track` |
| Layout size | `?size` |
| Intermittent display | `?blink` |
| Intermittent interval (4–20s) | `?interval` |

Example: `/public/event/<id>/intermission?track=track1&size=50&blink=1&interval=12`

## How

- New `useQueryParam` hook: reads the initial value from the URL, writes changes back via `history.replaceState` (no navigation). Each setter reads the current search fresh so independent params don't clobber each other.
- `IntermissionApp` — selected track → `?track`.
- `IntermissionScreen` — cog options (size / intermittent / interval) → query params (replacing the previous localStorage-backed state).

## Security note

The optional intermission **password stays in `localStorage` and is never put in the URL** (no secrets in query strings).

## Verification

- Verified in the in-Claude preview against the local Firebase emulator: picking a track and changing each cog option updates the URL; a full reload restores track, size (`scale(0.5)`), intermittent toggle, and interval from the URL.
- `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)